### PR TITLE
Improve debug logging

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { output } from './helpers';
+import { log } from './helpers';
 
 export const configSection = 'vscode-attack';
 export let completionFormat = 'id';
@@ -8,11 +8,11 @@ export let debug = true;
 export function setDebugLogState(): void {
     if (vscode.workspace.getConfiguration(configSection).get('debug')) {
         debug = true;
-        output.appendLine('Debug logging enabled');
+        log('Debug logging enabled');
     }
     else {
         debug = false;
-        output.appendLine('Debug logging disabled');
+        log('Debug logging disabled');
     }
 }
 
@@ -26,7 +26,6 @@ export async function setCompletionItemFormat(): Promise<void> {
     }
     if (newCompletionFormat !== undefined) {
         completionFormat = newCompletionFormat;
-        // console.log(`Set completion item format to '${completionFormat}'`);
-        if (debug) { output.appendLine(`Set completion item format to '${completionFormat}'`); }
+        if (debug) { log(`Set completion item format to '${completionFormat}'`); }
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,7 @@ const Providers = {
     techniques: new Array<vscode.Disposable>(),
     disposeAll: function (): void {
         // dispose of all providers at once
-        log('Disposing of all providers');
+        if (debug) { log('Disposing of all providers'); }
         this.groups.forEach((d: vscode.Disposable) => { d.dispose(); });
         this.mitigations.forEach((d: vscode.Disposable) => { d.dispose(); });
         this.software.forEach((d: vscode.Disposable) => { d.dispose(); });
@@ -31,7 +31,7 @@ const Providers = {
     pushAll: function (list: Array<vscode.Disposable>): void {
         // push all providers to the given list
         // ... should be used to push into the extension's context
-        log('Building list of all providers');
+        if (debug) { log('Building list of all providers'); }
         this.groups.forEach((d: vscode.Disposable) => { list.push(d); });
         this.mitigations.forEach((d: vscode.Disposable) => { list.push(d); });
         this.software.forEach((d: vscode.Disposable) => { list.push(d); });
@@ -58,6 +58,7 @@ export async function cacheData(storageDir: string): Promise<AttackMap|undefined
         const cachedPath: string|undefined = await helpers.getLatestCacheVersion(storageDir);
         if (cachedPath === undefined) {
             // no files found - download the latest version from GitHub
+            log('Nothing found in extension cache. Downloading latest version of MITRE ATT&CK mapping');
             result = await helpers.downloadLatestAttackMap(storageDir);
         }
         else {
@@ -69,12 +70,12 @@ export async function cacheData(storageDir: string): Promise<AttackMap|undefined
             if (cachedVersion < onlineVersion) {
                 // if online version is newer than the cached one, download and use the online version
                 vscode.window.showInformationMessage('ATT&CK: Identified a new version of the ATT&CK mapping! Replacing cached version.');
-                log('Identified a new version of the ATT&CK mapping! Replacing cached version.');
+                log(`Identified a new version of the ATT&CK mapping! Replacing cached map (${cachedVersion}) with downloaded map (${onlineVersion})`);
                 result = await helpers.downloadLatestAttackMap(storageDir);
             }
             else {
                 // otherwise just use the cached one
-                log('Cached version is not older than downloaded version. Nothing to do.');
+                log(`Nothing to do. Cached version is on latest ATT&CK version ${onlineVersion}`);
                 const cachedData: string = fs.readFileSync(cachedPath, {encoding: 'utf8'});
                 result = JSON.parse(cachedData) as AttackMap;
             }

--- a/src/groups.ts
+++ b/src/groups.ts
@@ -99,6 +99,7 @@ export class GroupHoverProvider implements vscode.HoverProvider {
                     const hoverTerm: string = document.getText(hoverRange);
                     const currentGroup: Group | undefined = this.groups.find((g: Group) => { return g.id === hoverTerm; });
                     if (currentGroup !== undefined) {
+                        if (debug) { log(`GroupHoverProvider: Found exact Group ID '${currentGroup.id}'`); }
                         hover = new vscode.Hover(buildGroupDescription(currentGroup), hoverRange);
                     }
                 }
@@ -131,11 +132,10 @@ export class GroupCompletionProvider implements vscode.CompletionItemProvider {
                     const completionTerm: string = document.getText(completionRange);
                     // only return everything if this is a "long" term
                     if (completionTerm.length >= minTermLength) {
-                        if (debug) { log(`GroupCompletionProvider: Completion term: ${completionTerm}`); }
                         // if the user is trying to complete something that matches an exact group ID, just return that one item
                         const group: Group | undefined = this.groups.find((g: Group) => { return g.id === completionTerm.toUpperCase(); });
                         if (group !== undefined) {
-                            if (debug) { log(`GroupCompletionProvider: Found exact technique ID '${group.id}'`); }
+                            if (debug) { log(`GroupCompletionProvider: Found exact Group ID '${group.id}'`); }
                             completionItems = [buildCompletionItem(group.id, group)];
                         }
                         else {
@@ -145,6 +145,7 @@ export class GroupCompletionProvider implements vscode.CompletionItemProvider {
                             });
                             if (possibleGroups !== undefined) {
                                 completionItems = possibleGroups.map<vscode.CompletionItem>((g: Group) => {
+                                    if (debug) { log(`GroupCompletionProvider: Found possible Group '${g.name}'`); }
                                     return buildCompletionItem(g.name, g);
                                 });
                             }
@@ -183,7 +184,7 @@ export class GroupCompletionProvider implements vscode.CompletionItemProvider {
 }
 
 export function register(filters: vscode.DocumentSelector, groups: Array<Group>): Array<vscode.Disposable> {
-    log('Registering providers for groups');
+    log('Registering providers for Groups');
     // hover provider
     const groupHovers: GroupHoverProvider = new GroupHoverProvider();
     const groupHoverDisposable: vscode.Disposable = vscode.languages.registerHoverProvider(filters, groupHovers);

--- a/src/groups.ts
+++ b/src/groups.ts
@@ -89,7 +89,7 @@ export class GroupHoverProvider implements vscode.HoverProvider {
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
-                    if (debug) { log('Group hover provider cancelled!'); }
+                    if (debug) { log('GroupHoverProvider: Task cancelled!'); }
                     resolve(undefined);
                 });
                 let hover: vscode.Hover | undefined = undefined;
@@ -119,7 +119,7 @@ export class GroupCompletionProvider implements vscode.CompletionItemProvider {
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
-                    if (debug) { log('Group completion provider cancelled!'); }
+                    if (debug) { log('GroupCompletionProvider: Task cancelled!'); }
                     resolve(undefined);
                 });
                 let completionItems: Array<vscode.CompletionItem> = new Array<vscode.CompletionItem>();
@@ -164,7 +164,7 @@ export class GroupCompletionProvider implements vscode.CompletionItemProvider {
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
-                    if (debug) { log('Group completion resolver cancelled!'); }
+                    if (debug) { log('GroupCompletionProvider: Resolution task cancelled!'); }
                     resolve(undefined);
                 });
                 if (debug) { log(`GroupCompletionProvider: Resolving completion item for '${item.label}'`); }

--- a/src/groups.ts
+++ b/src/groups.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { completionFormat, configSection, debug } from './configuration';
-import { minTermLength, output, groupRegex } from './helpers';
+import { minTermLength, log, groupRegex } from './helpers';
 
 /*
     Build a completion item's insertion text based on settings
@@ -76,7 +76,7 @@ export async function init(attackData: AttackMap): Promise<Array<Group>> {
             });
             return group;
         });
-        if (debug) { output.appendLine(`Parsed out ${groups.length} groups`); }
+        if (debug) { log(`Parsed out ${groups.length} groups`); }
         resolve(groups);
     });
 }
@@ -89,6 +89,7 @@ export class GroupHoverProvider implements vscode.HoverProvider {
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
+                    if (debug) { log('Group hover provider cancelled!'); }
                     resolve(undefined);
                 });
                 let hover: vscode.Hover | undefined = undefined;
@@ -96,7 +97,6 @@ export class GroupHoverProvider implements vscode.HoverProvider {
                 hoverRange = document.getWordRangeAtPosition(position, groupRegex);
                 if (hoverRange !== undefined) {
                     const hoverTerm: string = document.getText(hoverRange);
-                    if (debug) { output.appendLine(`provideHover: Hover term: ${hoverTerm}`); }
                     const currentGroup: Group | undefined = this.groups.find((g: Group) => { return g.id === hoverTerm; });
                     if (currentGroup !== undefined) {
                         hover = new vscode.Hover(buildGroupDescription(currentGroup), hoverRange);
@@ -105,7 +105,7 @@ export class GroupHoverProvider implements vscode.HoverProvider {
                 resolve(hover);
             });
         } catch (error) {
-            output.appendLine(`provideHover error: ${error}`);
+            log(`GroupHoverProvider error: ${error}`);
         }
     }
 }
@@ -118,29 +118,24 @@ export class GroupCompletionProvider implements vscode.CompletionItemProvider {
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
+                    if (debug) { log('Group completion provider cancelled!'); }
                     resolve(undefined);
                 });
                 let completionItems: Array<vscode.CompletionItem> = new Array<vscode.CompletionItem>();
                 let dbgMsg = '';
                 const completionRange: vscode.Range | undefined = document.getWordRangeAtPosition(position);
                 if (completionRange === undefined) {
-                    dbgMsg = `GroupCompletionProvider: No completion item range provided.`;
-                    console.log(dbgMsg);
-                    if (debug) { output.appendLine(dbgMsg); }
+                    if (debug) { log('GroupCompletionProvider: No completion item range provided.'); }
                 }
                 else {
                     const completionTerm: string = document.getText(completionRange);
                     // only return everything if this is a "long" term
                     if (completionTerm.length >= minTermLength) {
-                        dbgMsg = `GroupCompletionProvider: Completion term: ${completionTerm}`;
-                        console.log(dbgMsg);
-                        if (debug) { output.appendLine(dbgMsg); }
+                        if (debug) { log(`GroupCompletionProvider: Completion term: ${completionTerm}`); }
                         // if the user is trying to complete something that matches an exact group ID, just return that one item
                         const group: Group | undefined = this.groups.find((g: Group) => { return g.id === completionTerm.toUpperCase(); });
                         if (group !== undefined) {
-                            dbgMsg = `GroupCompletionProvider: Found exact technique ID '${group.id}'`;
-                            console.log(dbgMsg);
-                            if (debug) { output.appendLine(dbgMsg); }
+                            if (debug) { log(`GroupCompletionProvider: Found exact technique ID '${group.id}'`); }
                             completionItems = [buildCompletionItem(group.id, group)];
                         }
                         else {
@@ -159,7 +154,7 @@ export class GroupCompletionProvider implements vscode.CompletionItemProvider {
                 resolve(completionItems);
             });
         } catch (error) {
-            output.appendLine(`GroupCompletionProvider error: ${error}`);
+            log(`GroupCompletionProvider error: ${error}`);
         }
     }
 
@@ -168,9 +163,10 @@ export class GroupCompletionProvider implements vscode.CompletionItemProvider {
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
+                    if (debug) { log('Group completion resolver cancelled!'); }
                     resolve(undefined);
                 });
-                // console.log(`GroupCompletionProvider: Received completion item with label: ${item.label}`);
+                if (debug) { log(`GroupCompletionProvider: Resolving completion item for '${item.label}'`); }
                 item.keepWhitespace = true;
                 const group: Group | undefined = this.groups.find((g: Group) => {
                     return (g.id === item.label) || (g.name === item.label);
@@ -181,12 +177,13 @@ export class GroupCompletionProvider implements vscode.CompletionItemProvider {
                 resolve(item);
             });
         } catch (error) {
-            output.appendLine(`GroupCompletionProvider error: ${error}`);
+            log(`GroupCompletionProvider error: ${error}`);
         }
     }
 }
 
 export function register(filters: vscode.DocumentSelector, groups: Array<Group>): Array<vscode.Disposable> {
+    log('Registering providers for groups');
     // hover provider
     const groupHovers: GroupHoverProvider = new GroupHoverProvider();
     const groupHoverDisposable: vscode.Disposable = vscode.languages.registerHoverProvider(filters, groupHovers);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -20,6 +20,12 @@ export const mitigationRegex = /M\d{4}/;
 // everything under this will only show the technique provider's results
 export const minTermLength = 5;
 
+
+export function log(message: string): void {
+    const currTime: Date = new Date();
+    output.appendLine(`[${currTime.toISOString()}] ${message}`);
+}
+
 /*
     Parse the last modified time of the given ATT&CK mapping
 */

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -20,10 +20,11 @@ export const mitigationRegex = /M\d{4}/;
 // everything under this will only show the technique provider's results
 export const minTermLength = 5;
 
-
+/*
+    Send a given message to the MITRE ATT&CK output channel with a timestamp
+*/
 export function log(message: string): void {
-    const currTime: Date = new Date();
-    output.appendLine(`[${currTime.toISOString()}] ${message}`);
+    output.appendLine(`[${new Date().toISOString()}] ${message}`);
 }
 
 /*
@@ -73,8 +74,7 @@ export function getVersions(prefix = 'ATT&CK-v'): Promise<Array<string>> {
             res.on('data', (chunk) => { downloadedData = downloadedData.concat(chunk); });
             res.on('error', (err: Error) => {
                 // something bad happened! let the user know
-                console.log(`ATT&CK: Could not retrieve the version list! ${err.message}`);
-                output.appendLine(`Could not retrieve the version list! ${err.message}`);
+                log(`Could not retrieve the version list! ${err.message}`);
                 vscode.window.showErrorMessage(`ATT&CK: Could not retrieve the version list! ${err.message}`);
                 reject(err);
             });
@@ -136,23 +136,20 @@ export function downloadAttackMap(storageDir: string, version: string): Promise<
                     res.on('data', (chunk) => { downloadedData = downloadedData.concat(chunk); });
                     res.on('error', (err: Error) => {
                         // something bad happened! let the user know
-                        output.appendLine(`Something went wrong while downloading ATT&CK mapping! ${err.message}`);
+                        log(`Something went wrong while downloading ATT&CK mapping! ${err.message}`);
                         vscode.window.showErrorMessage(`ATT&CK: Something went wrong while downloading ATT&CK mapping v${version}! ${err.message}`);
-                        console.log(`ATT&CK: Something went wrong while downloading ATT&CK mapping! ${err.message}`);
                         reject(err);
                     });
                     res.on('end', () => {
-                        console.log(`Attempting to write contents to ${storagePath}`);
                         // save the JSON file to the global storage path
                         fs.writeFileSync(storagePath, downloadedData.toString());
-                        output.appendLine(`Successfully cached the Enterprise ATT&CK v${version} data @ '${storagePath}'!`);
-                        console.log(`Successfully cached the Enterprise ATT&CK v${version} data @ '${storagePath}'!`);
+                        log(`Successfully cached the Enterprise ATT&CK v${version} data @ '${storagePath}'!`);
                         resolve(downloadedData);
                     });
                 });
             }
             else {
-                console.log(`Could not find version ${version} in the tags list: ${availableVersions}`);
+                log(`Could not find version ${version} in the tags list: ${availableVersions}`);
                 resolve(downloadedData);
             }
         });
@@ -182,7 +179,7 @@ export function getLatestCacheVersion(cacheDir: string): Promise<string|undefine
         let latestVersionPath: string|undefined = undefined;
         fs.readdir(cacheDir, (err, files) => {
             if (err) {
-                console.log(`Couldn't read files from ${cacheDir}! ${err.message}`);
+                log(`Couldn't read files from ${cacheDir}! ${err.message}`);
                 reject(err);
             }
             else {

--- a/src/mitigations.ts
+++ b/src/mitigations.ts
@@ -97,6 +97,7 @@ export class MitigationHoverProvider implements vscode.HoverProvider {
                     const hoverTerm: string = document.getText(hoverRange);
                     const currentMitigation: Mitigation | undefined = this.mitigations.find((g: Mitigation) => { return g.id === hoverTerm; });
                     if (currentMitigation !== undefined) {
+                        if (debug) { log(`MitigationHoverProvider: Found exact Mitigation ID '${currentMitigation.id}'`); }
                         hover = new vscode.Hover(buildMitigationDescription(currentMitigation), hoverRange);
                     }
                 }
@@ -129,11 +130,10 @@ export class MitigationCompletionProvider implements vscode.CompletionItemProvid
                     const completionTerm: string = document.getText(completionRange);
                     // only return everything if this is a "long" term
                     if (completionTerm.length >= minTermLength) {
-                        if (debug) { log(`MitigationCompletionProvider: Completion term: ${completionTerm}`); }
                         // if the user is trying to complete something that matches an exact mitigation ID, just return that one item
                         const mitigation: Mitigation | undefined = this.mitigations.find((g: Mitigation) => { return g.id === completionTerm.toUpperCase(); });
                         if (mitigation !== undefined) {
-                            if (debug) { log(`MitigationCompletionProvider: Found exact technique ID '${mitigation.id}'`); }
+                            if (debug) { log(`MitigationCompletionProvider: Found exact Mitigation ID '${mitigation.id}'`); }
                             completionItems = [buildCompletionItem(mitigation.id, mitigation)];
                         }
                         else {
@@ -142,8 +142,9 @@ export class MitigationCompletionProvider implements vscode.CompletionItemProvid
                                 return s.name.toLowerCase().includes(completionTerm.toLowerCase());
                             });
                             if (possibleMitigation !== undefined) {
-                                completionItems = possibleMitigation.map<vscode.CompletionItem>((s: Mitigation) => {
-                                    return buildCompletionItem(s.name, s);
+                                completionItems = possibleMitigation.map<vscode.CompletionItem>((m: Mitigation) => {
+                                    if (debug) { log(`MitigationCompletionProvider: Found possible Mitigation '${m.name}'`); }
+                                    return buildCompletionItem(m.name, m);
                                 });
                             }
                         }
@@ -181,7 +182,7 @@ export class MitigationCompletionProvider implements vscode.CompletionItemProvid
 }
 
 export function register(filters: vscode.DocumentSelector, mitigations: Array<Mitigation>): Array<vscode.Disposable> {
-    log('Registering providers for mitigations');
+    log('Registering providers for Mitigations');
     // hover provider
     const mitigationHovers: MitigationHoverProvider = new MitigationHoverProvider();
     const mitigationHoverDisposable: vscode.Disposable = vscode.languages.registerHoverProvider(filters, mitigationHovers);

--- a/src/mitigations.ts
+++ b/src/mitigations.ts
@@ -87,7 +87,7 @@ export class MitigationHoverProvider implements vscode.HoverProvider {
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
-                    if (debug) { log('Mitigation hover provider cancelled!'); }
+                    if (debug) { log('MitigationHoverProvider: Task cancelled!'); }
                     resolve(undefined);
                 });
                 let hover: vscode.Hover | undefined = undefined;
@@ -117,7 +117,7 @@ export class MitigationCompletionProvider implements vscode.CompletionItemProvid
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
-                    if (debug) { log('Mitigation completion provider cancelled!'); }
+                    if (debug) { log('MitigationCompletionProvider: Task cancelled!'); }
                     resolve(undefined);
                 });
                 let completionItems: Array<vscode.CompletionItem> = new Array<vscode.CompletionItem>();
@@ -162,7 +162,7 @@ export class MitigationCompletionProvider implements vscode.CompletionItemProvid
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
-                    if (debug) { log('Mitigation completion resolver cancelled!'); }
+                    if (debug) { log('MitigationCompletionProvider: Resolution task cancelled!'); }
                     resolve(undefined);
                 });
                 if (debug) { log(`MitigationCompletionProvider: Resolving completion item for '${item.label}'`); }

--- a/src/mitigations.ts
+++ b/src/mitigations.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { completionFormat, configSection, debug } from './configuration';
-import { minTermLength, output, mitigationRegex } from './helpers';
+import { minTermLength, log, mitigationRegex } from './helpers';
 
 /*
     Build a completion item's insertion text based on settings
@@ -74,7 +74,7 @@ export async function init(attackData: AttackMap): Promise<Array<Mitigation>> {
         // certain techniques have their own mitigation entry with an ID that matches their technique ID
         // ... filter these out, as they are not generally useful
         mitigations = mitigations.filter((mitigation: Mitigation) => { return mitigation.id.match(mitigationRegex); });
-        if (debug) { output.appendLine(`Parsed out ${mitigations.length} mitigations`); }
+        if (debug) { log(`Parsed out ${mitigations.length} mitigations`); }
         resolve(mitigations);
     });
 }
@@ -87,6 +87,7 @@ export class MitigationHoverProvider implements vscode.HoverProvider {
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
+                    if (debug) { log('Mitigation hover provider cancelled!'); }
                     resolve(undefined);
                 });
                 let hover: vscode.Hover | undefined = undefined;
@@ -94,7 +95,6 @@ export class MitigationHoverProvider implements vscode.HoverProvider {
                 hoverRange = document.getWordRangeAtPosition(position, mitigationRegex);
                 if (hoverRange !== undefined) {
                     const hoverTerm: string = document.getText(hoverRange);
-                    if (debug) { output.appendLine(`provideHover: Hover term: ${hoverTerm}`); }
                     const currentMitigation: Mitigation | undefined = this.mitigations.find((g: Mitigation) => { return g.id === hoverTerm; });
                     if (currentMitigation !== undefined) {
                         hover = new vscode.Hover(buildMitigationDescription(currentMitigation), hoverRange);
@@ -103,7 +103,7 @@ export class MitigationHoverProvider implements vscode.HoverProvider {
                 resolve(hover);
             });
         } catch (error) {
-            output.appendLine(`provideHover error: ${error}`);
+            log(`MitigationHoverProvider error: ${error}`);
         }
     }
 }
@@ -116,29 +116,24 @@ export class MitigationCompletionProvider implements vscode.CompletionItemProvid
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
+                    if (debug) { log('Mitigation completion provider cancelled!'); }
                     resolve(undefined);
                 });
                 let completionItems: Array<vscode.CompletionItem> = new Array<vscode.CompletionItem>();
                 let dbgMsg = '';
                 const completionRange: vscode.Range | undefined = document.getWordRangeAtPosition(position);
                 if (completionRange === undefined) {
-                    dbgMsg = `MitigationCompletionProvider: No completion item range provided.`;
-                    console.log(dbgMsg);
-                    if (debug) { output.appendLine(dbgMsg); }
+                    if (debug) { log('MitigationCompletionProvider: No completion item range provided.'); }
                 }
                 else {
                     const completionTerm: string = document.getText(completionRange);
                     // only return everything if this is a "long" term
                     if (completionTerm.length >= minTermLength) {
-                        dbgMsg = `MitigationCompletionProvider: Completion term: ${completionTerm}`;
-                        console.log(dbgMsg);
-                        if (debug) { output.appendLine(dbgMsg); }
+                        if (debug) { log(`MitigationCompletionProvider: Completion term: ${completionTerm}`); }
                         // if the user is trying to complete something that matches an exact mitigation ID, just return that one item
                         const mitigation: Mitigation | undefined = this.mitigations.find((g: Mitigation) => { return g.id === completionTerm.toUpperCase(); });
                         if (mitigation !== undefined) {
-                            dbgMsg = `MitigationCompletionProvider: Found exact technique ID '${mitigation.id}'`;
-                            console.log(dbgMsg);
-                            if (debug) { output.appendLine(dbgMsg); }
+                            if (debug) { log(`MitigationCompletionProvider: Found exact technique ID '${mitigation.id}'`); }
                             completionItems = [buildCompletionItem(mitigation.id, mitigation)];
                         }
                         else {
@@ -157,7 +152,7 @@ export class MitigationCompletionProvider implements vscode.CompletionItemProvid
                 resolve(completionItems);
             });
         } catch (error) {
-            output.appendLine(`MitigationCompletionProvider error: ${error}`);
+            log(`MitigationCompletionProvider error: ${error}`);
         }
     }
 
@@ -166,8 +161,10 @@ export class MitigationCompletionProvider implements vscode.CompletionItemProvid
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
+                    if (debug) { log('Mitigation completion resolver cancelled!'); }
                     resolve(undefined);
                 });
+                if (debug) { log(`MitigationCompletionProvider: Resolving completion item for '${item.label}'`); }
                 item.keepWhitespace = true;
                 const mitigation: Mitigation | undefined = this.mitigations.find((g: Mitigation) => {
                     return (g.id === item.label) || (g.name === item.label);
@@ -178,12 +175,13 @@ export class MitigationCompletionProvider implements vscode.CompletionItemProvid
                 resolve(item);
             });
         } catch (error) {
-            output.appendLine(`MitigationCompletionProvider error: ${error}`);
+            log(`MitigationCompletionProvider error: ${error}`);
         }
     }
 }
 
 export function register(filters: vscode.DocumentSelector, mitigations: Array<Mitigation>): Array<vscode.Disposable> {
+    log('Registering providers for mitigations');
     // hover provider
     const mitigationHovers: MitigationHoverProvider = new MitigationHoverProvider();
     const mitigationHoverDisposable: vscode.Disposable = vscode.languages.registerHoverProvider(filters, mitigationHovers);

--- a/src/software.ts
+++ b/src/software.ts
@@ -89,7 +89,7 @@ export class SoftwareHoverProvider implements vscode.HoverProvider {
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
-                    if (debug) { log('Software hover provider cancelled!'); }
+                    if (debug) { log('SoftwareHoverProvider: Task cancelled!'); }
                     resolve(undefined);
                 });
                 let hover: vscode.Hover | undefined = undefined;
@@ -119,7 +119,7 @@ export class SoftwareCompletionProvider implements vscode.CompletionItemProvider
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
-                    if (debug) { log('Software completion provider cancelled!'); }
+                    if (debug) { log('SoftwareCompletionProvider: Task cancelled!'); }
                     resolve(undefined);
                 });
                 let completionItems: Array<vscode.CompletionItem> = new Array<vscode.CompletionItem>();
@@ -164,7 +164,7 @@ export class SoftwareCompletionProvider implements vscode.CompletionItemProvider
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
-                    if (debug) { log('Software completion resolver cancelled!'); }
+                    if (debug) { log('SoftwareCompletionProvider: Resolution task cancelled!'); }
                     resolve(undefined);
                 });
                 if (debug) { log(`SoftwareCompletionProvider: Resolving completion item for '${item.label}'`); }

--- a/src/software.ts
+++ b/src/software.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { completionFormat, configSection, debug } from './configuration';
-import { minTermLength, output, softwareRegex } from './helpers';
+import { minTermLength, log, softwareRegex } from './helpers';
 
 /*
     Build a completion item's insertion text based on settings
@@ -76,7 +76,7 @@ export async function init(attackData: AttackMap): Promise<Array<Software>> {
             });
             return software;
         });
-        if (debug) { output.appendLine(`Parsed out ${softwares.length} softwares`); }
+        if (debug) { log(`Parsed out ${softwares.length} softwares`); }
         resolve(softwares);
     });
 }
@@ -89,6 +89,7 @@ export class SoftwareHoverProvider implements vscode.HoverProvider {
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
+                    if (debug) { log('Software hover provider cancelled!'); }
                     resolve(undefined);
                 });
                 let hover: vscode.Hover | undefined = undefined;
@@ -96,7 +97,6 @@ export class SoftwareHoverProvider implements vscode.HoverProvider {
                 hoverRange = document.getWordRangeAtPosition(position, softwareRegex);
                 if (hoverRange !== undefined) {
                     const hoverTerm: string = document.getText(hoverRange);
-                    if (debug) { output.appendLine(`provideHover: Hover term: ${hoverTerm}`); }
                     const currentSoftware: Software | undefined = this.software.find((g: Software) => { return g.id === hoverTerm; });
                     if (currentSoftware !== undefined) {
                         hover = new vscode.Hover(buildSoftwareDescription(currentSoftware), hoverRange);
@@ -105,7 +105,7 @@ export class SoftwareHoverProvider implements vscode.HoverProvider {
                 resolve(hover);
             });
         } catch (error) {
-            output.appendLine(`provideHover error: ${error}`);
+            log(`SoftwareHoverProvider error: ${error}`);
         }
     }
 }
@@ -118,29 +118,24 @@ export class SoftwareCompletionProvider implements vscode.CompletionItemProvider
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
+                    if (debug) { log('Software completion provider cancelled!'); }
                     resolve(undefined);
                 });
                 let completionItems: Array<vscode.CompletionItem> = new Array<vscode.CompletionItem>();
                 let dbgMsg = '';
                 const completionRange: vscode.Range | undefined = document.getWordRangeAtPosition(position);
                 if (completionRange === undefined) {
-                    dbgMsg = `SoftwareCompletionProvider: No completion item range provided.`;
-                    console.log(dbgMsg);
-                    if (debug) { output.appendLine(dbgMsg); }
+                    if (debug) { log('SoftwareCompletionProvider: No completion item range provided.'); }
                 }
                 else {
                     const completionTerm: string = document.getText(completionRange);
                     // only return everything if this is a "long" term
                     if (completionTerm.length >= minTermLength) {
-                        dbgMsg = `SoftwareCompletionProvider: Completion term: ${completionTerm}`;
-                        console.log(dbgMsg);
-                        if (debug) { output.appendLine(dbgMsg); }
+                        if (debug) { log(`SoftwareCompletionProvider: Completion term: ${completionTerm}`); }
                         // if the user is trying to complete something that matches an exact software ID, just return that one item
                         const software: Software | undefined = this.software.find((g: Software) => { return g.id === completionTerm.toUpperCase(); });
                         if (software !== undefined) {
-                            dbgMsg = `SoftwareCompletionProvider: Found exact technique ID '${software.id}'`;
-                            console.log(dbgMsg);
-                            if (debug) { output.appendLine(dbgMsg); }
+                            if (debug) { log(`SoftwareCompletionProvider: Found exact technique ID '${software.id}'`); }
                             completionItems = [buildCompletionItem(software.id, software)];
                         }
                         else {
@@ -159,7 +154,7 @@ export class SoftwareCompletionProvider implements vscode.CompletionItemProvider
                 resolve(completionItems);
             });
         } catch (error) {
-            output.appendLine(`SoftwareCompletionProvider error: ${error}`);
+            log(`SoftwareCompletionProvider error: ${error}`);
         }
     }
 
@@ -168,9 +163,10 @@ export class SoftwareCompletionProvider implements vscode.CompletionItemProvider
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
+                    if (debug) { log('Software completion resolver cancelled!'); }
                     resolve(undefined);
                 });
-                // console.log(`SoftwareCompletionProvider: Received completion item with label: ${item.label}`);
+                if (debug) { log(`SoftwareCompletionProvider: Resolving completion item for '${item.label}'`); }
                 item.keepWhitespace = true;
                 const software: Software | undefined = this.software.find((g: Software) => {
                     return (g.id === item.label) || (g.name === item.label);
@@ -181,12 +177,13 @@ export class SoftwareCompletionProvider implements vscode.CompletionItemProvider
                 resolve(item);
             });
         } catch (error) {
-            output.appendLine(`SoftwareCompletionProvider error: ${error}`);
+            log(`SoftwareCompletionProvider error: ${error}`);
         }
     }
 }
 
 export function register(filters: vscode.DocumentSelector, tools: Array<Software>): Array<vscode.Disposable> {
+    log('Registering providers for software');
     // hover provider
     const softwareHovers: SoftwareHoverProvider = new SoftwareHoverProvider();
     const softwareHoverDisposable: vscode.Disposable = vscode.languages.registerHoverProvider(filters, softwareHovers);

--- a/src/software.ts
+++ b/src/software.ts
@@ -99,6 +99,7 @@ export class SoftwareHoverProvider implements vscode.HoverProvider {
                     const hoverTerm: string = document.getText(hoverRange);
                     const currentSoftware: Software | undefined = this.software.find((g: Software) => { return g.id === hoverTerm; });
                     if (currentSoftware !== undefined) {
+                        if (debug) { log(`SoftwareHoverProvider: Found exact Software ID '${currentSoftware.id}'`); }
                         hover = new vscode.Hover(buildSoftwareDescription(currentSoftware), hoverRange);
                     }
                 }
@@ -135,7 +136,7 @@ export class SoftwareCompletionProvider implements vscode.CompletionItemProvider
                         // if the user is trying to complete something that matches an exact software ID, just return that one item
                         const software: Software | undefined = this.software.find((g: Software) => { return g.id === completionTerm.toUpperCase(); });
                         if (software !== undefined) {
-                            if (debug) { log(`SoftwareCompletionProvider: Found exact technique ID '${software.id}'`); }
+                            if (debug) { log(`SoftwareCompletionProvider: Found exact Software ID '${software.id}'`); }
                             completionItems = [buildCompletionItem(software.id, software)];
                         }
                         else {
@@ -183,7 +184,7 @@ export class SoftwareCompletionProvider implements vscode.CompletionItemProvider
 }
 
 export function register(filters: vscode.DocumentSelector, tools: Array<Software>): Array<vscode.Disposable> {
-    log('Registering providers for software');
+    log('Registering providers for Software');
     // hover provider
     const softwareHovers: SoftwareHoverProvider = new SoftwareHoverProvider();
     const softwareHoverDisposable: vscode.Disposable = vscode.languages.registerHoverProvider(filters, softwareHovers);

--- a/src/tactics.ts
+++ b/src/tactics.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { completionFormat, configSection, debug } from './configuration';
-import { minTermLength, output, tacticRegex } from './helpers';
+import { minTermLength, log, tacticRegex } from './helpers';
 
 /*
     Build a completion item's insertion text based on settings
@@ -68,7 +68,7 @@ export async function init(attackData: AttackMap): Promise<Tactic[]> {
             });
             return tactic;
         });
-        if (debug) { output.appendLine(`Parsed out ${tactics.length} tactics`); }
+        if (debug) { log(`Parsed out ${tactics.length} tactics`); }
         resolve(tactics);
     });
 }
@@ -81,6 +81,7 @@ export class TacticHoverProvider implements vscode.HoverProvider {
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
+                    if (debug) { log('Tactic hover provider cancelled!'); }
                     resolve(undefined);
                 });
                 let hover: vscode.Hover | undefined = undefined;
@@ -89,7 +90,6 @@ export class TacticHoverProvider implements vscode.HoverProvider {
                 hoverRange = document.getWordRangeAtPosition(position, tacticRegex);
                 if (hoverRange !== undefined) {
                     const hoverTerm: string = document.getText(hoverRange);
-                    if (debug) { output.appendLine(`provideHover: Hover term: ${hoverTerm}`); }
                     const currentTactic: Tactic | undefined = this.tactics.find((t: Tactic) => { return t.id === hoverTerm; });
                     if (currentTactic !== undefined) {
                         hover = new vscode.Hover(buildTacticDescription(currentTactic), hoverRange);
@@ -98,7 +98,7 @@ export class TacticHoverProvider implements vscode.HoverProvider {
                 resolve(hover);
             });
         } catch (error) {
-            output.appendLine(`provideHover error: ${error}`);
+            log(`TacticHoverProvider error: ${error}`);
         }
     }
 }
@@ -111,29 +111,24 @@ export class TacticCompletionProvider implements vscode.CompletionItemProvider {
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
+                    if (debug) { log('Tactic completion provider cancelled!'); }
                     resolve(undefined);
                 });
                 let completionItems: Array<vscode.CompletionItem> = new Array<vscode.CompletionItem>();
                 let dbgMsg = '';
                 const completionRange: vscode.Range | undefined = document.getWordRangeAtPosition(position);
                 if (completionRange === undefined) {
-                    dbgMsg = `TacticCompletionProvider: No completion item range provided.`;
-                    console.log(dbgMsg);
-                    if (debug) { output.appendLine(dbgMsg); }
+                    if (debug) { log('TacticCompletionProvider: No completion item range provided.'); }
                 }
                 else {
                     const completionTerm: string = document.getText(completionRange);
                     // only return everything if this is a "long" term
                     if (completionTerm.length >= minTermLength) {
-                        dbgMsg = `TacticCompletionProvider: Completion term: ${completionTerm}`;
-                        console.log(dbgMsg);
-                        if (debug) { output.appendLine(dbgMsg); }
+                        if (debug) { log(`TacticCompletionProvider: Completion term: ${completionTerm}`); }
                         // if the user is trying to complete something that matches an exact technique ID, just return that one item
                         const tactic: Tactic | undefined = this.tactics.find((t: Tactic) => { return t.id === completionTerm.toUpperCase(); });
                         if (tactic !== undefined) {
-                            dbgMsg = `TacticCompletionProvider: Found exact technique ID '${tactic.id}'`;
-                            console.log(dbgMsg);
-                            if (debug) { output.appendLine(dbgMsg); }
+                            if (debug) { log(`TacticCompletionProvider: Found exact technique ID '${tactic.id}'`); }
                             completionItems = [buildCompletionItem(tactic.id, tactic)];
                         }
                         else {
@@ -152,7 +147,7 @@ export class TacticCompletionProvider implements vscode.CompletionItemProvider {
                 resolve(completionItems);
             });
         } catch (error) {
-            output.appendLine(`TacticCompletionProvider error: ${error}`);
+            log(`TacticCompletionProvider error: ${error}`);
         }
     }
 
@@ -161,9 +156,10 @@ export class TacticCompletionProvider implements vscode.CompletionItemProvider {
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
+                    if (debug) { log('Tactic completion resolver cancelled!'); }
                     resolve(undefined);
                 });
-                // console.log(`TacticCompletionProvider: Received completion item with label: ${item.label}`);
+                if (debug) { log(`TacticCompletionProvider: Resolving completion item for '${item.label}'`); }
                 item.keepWhitespace = true;
                 const tactic: Tactic | undefined = this.tactics.find((t: Tactic) => {
                     return (t.id === item.label) || (t.name === item.label);
@@ -174,7 +170,7 @@ export class TacticCompletionProvider implements vscode.CompletionItemProvider {
                 resolve(item);
             });
         } catch (error) {
-            output.appendLine(`TacticCompletionProvider error: ${error}`);
+            log(`TacticCompletionProvider error: ${error}`);
         }
     }
 }
@@ -183,6 +179,7 @@ export class TacticCompletionProvider implements vscode.CompletionItemProvider {
     Register features for the given DocumentFilters and Tactics
 */
 export function register(filters: vscode.DocumentSelector, tactics: Array<Tactic>): Array<vscode.Disposable> {
+    log('Registering providers for tactics');
     // hover provider
     const tacticHovers: TacticHoverProvider = new TacticHoverProvider();
     const tacticHoverDisposable: vscode.Disposable = vscode.languages.registerHoverProvider(filters, tacticHovers);

--- a/src/tactics.ts
+++ b/src/tactics.ts
@@ -81,7 +81,7 @@ export class TacticHoverProvider implements vscode.HoverProvider {
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
-                    if (debug) { log('Tactic hover provider cancelled!'); }
+                    if (debug) { log('TacticHoverProvider: Task cancelled!'); }
                     resolve(undefined);
                 });
                 let hover: vscode.Hover | undefined = undefined;
@@ -112,7 +112,7 @@ export class TacticCompletionProvider implements vscode.CompletionItemProvider {
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
-                    if (debug) { log('Tactic completion provider cancelled!'); }
+                    if (debug) { log('TacticCompletionProvider: Task cancelled!'); }
                     resolve(undefined);
                 });
                 let completionItems: Array<vscode.CompletionItem> = new Array<vscode.CompletionItem>();
@@ -157,7 +157,7 @@ export class TacticCompletionProvider implements vscode.CompletionItemProvider {
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
-                    if (debug) { log('Tactic completion resolver cancelled!'); }
+                    if (debug) { log('TacticCompletionProvider: Resolution task cancelled!'); }
                     resolve(undefined);
                 });
                 if (debug) { log(`TacticCompletionProvider: Resolving completion item for '${item.label}'`); }

--- a/src/tactics.ts
+++ b/src/tactics.ts
@@ -92,6 +92,7 @@ export class TacticHoverProvider implements vscode.HoverProvider {
                     const hoverTerm: string = document.getText(hoverRange);
                     const currentTactic: Tactic | undefined = this.tactics.find((t: Tactic) => { return t.id === hoverTerm; });
                     if (currentTactic !== undefined) {
+                        if (debug) { log(`TacticHoverProvider: Found exact Tactic ID '${currentTactic.id}'`); }
                         hover = new vscode.Hover(buildTacticDescription(currentTactic), hoverRange);
                     }
                 }
@@ -124,11 +125,10 @@ export class TacticCompletionProvider implements vscode.CompletionItemProvider {
                     const completionTerm: string = document.getText(completionRange);
                     // only return everything if this is a "long" term
                     if (completionTerm.length >= minTermLength) {
-                        if (debug) { log(`TacticCompletionProvider: Completion term: ${completionTerm}`); }
                         // if the user is trying to complete something that matches an exact technique ID, just return that one item
                         const tactic: Tactic | undefined = this.tactics.find((t: Tactic) => { return t.id === completionTerm.toUpperCase(); });
                         if (tactic !== undefined) {
-                            if (debug) { log(`TacticCompletionProvider: Found exact technique ID '${tactic.id}'`); }
+                            if (debug) { log(`TacticCompletionProvider: Found exact Tactic ID '${tactic.id}'`); }
                             completionItems = [buildCompletionItem(tactic.id, tactic)];
                         }
                         else {
@@ -138,6 +138,7 @@ export class TacticCompletionProvider implements vscode.CompletionItemProvider {
                             });
                             if (possibleTactics !== undefined) {
                                 completionItems = possibleTactics.map<vscode.CompletionItem>((t: Tactic) => {
+                                    if (debug) { log(`TacticCompletionProvider: Found possible Tactic '${t.name}'`); }
                                     return buildCompletionItem(t.name, t);
                                 });
                             }
@@ -179,7 +180,7 @@ export class TacticCompletionProvider implements vscode.CompletionItemProvider {
     Register features for the given DocumentFilters and Tactics
 */
 export function register(filters: vscode.DocumentSelector, tactics: Array<Tactic>): Array<vscode.Disposable> {
-    log('Registering providers for tactics');
+    log('Registering providers for Tactics');
     // hover provider
     const tacticHovers: TacticHoverProvider = new TacticHoverProvider();
     const tacticHoverDisposable: vscode.Disposable = vscode.languages.registerHoverProvider(filters, tacticHovers);

--- a/src/techniques.ts
+++ b/src/techniques.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { completionFormat, configSection, debug } from './configuration';
-import { minTermLength, output, techniqueRegex } from './helpers';
+import { minTermLength, log, techniqueRegex } from './helpers';
 
 let techniqueCompletionItems: Array<vscode.CompletionItem> = new Array<vscode.CompletionItem>();
 
@@ -81,8 +81,6 @@ function buildTechniqueDescription(technique: Technique, descriptionType: string
 */
 function generateCompletionItems(currentTechniques: Array<Technique>): void {
     const techniques: Array<Technique> = currentTechniques;
-    // console.log('Regenerating code completion items for techniques');
-    if (debug) { output.appendLine('Regenerating code completion items for techniques'); }
     techniqueCompletionItems = new Array<vscode.CompletionItem>();
     techniqueCompletionItems = techniques.map<vscode.CompletionItem>((t: Technique) => {
         const insertionText: string = buildInsertionText(t);
@@ -102,7 +100,6 @@ function generateCompletionItems(currentTechniques: Array<Technique>): void {
         if (t.deprecated || t.revoked) { completionItem.tags = [vscode.CompletionItemTag.Deprecated]; }
         return completionItem;
     });
-    // console.log(`generated ${techniqueCompletionItems.length} completion items`);
 }
 
 /*
@@ -149,13 +146,12 @@ export async function init(attackData: AttackMap): Promise<Technique[]> {
                 if (parentTID !== undefined) {
                     const parent: Technique | undefined = techniques.find((t: Technique) => { return t.id === parentTID; });
                     if (parent !== undefined) {
-                        // console.log(`Found '${technique.name}' (${technique.id}) is a subtechnique of '${parent.name}' (${parent.id})`);
                         technique.parent = parent;
                     }
                 }
             }
         });
-        if (debug) { output.appendLine(`Parsed out ${techniques.length} techniques`); }
+        if (debug) { log(`Parsed out ${techniques.length} techniques`); }
         resolve(techniques);
     });
 }
@@ -168,6 +164,7 @@ export class TechniqueHoverProvider implements vscode.HoverProvider {
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
+                    if (debug) { log('Technique hover provider cancelled!'); }
                     resolve(undefined);
                 });
                 let hover: vscode.Hover | undefined = undefined;
@@ -176,7 +173,6 @@ export class TechniqueHoverProvider implements vscode.HoverProvider {
                 hoverRange = document.getWordRangeAtPosition(position, techniqueRegex);
                 if (hoverRange !== undefined) {
                     const hoverTerm: string = document.getText(hoverRange);
-                    if (debug) { output.appendLine(`provideHover: Hover term: ${hoverTerm}`); }
                     const currentTechnique: Technique | undefined = this.techniques.find((t: Technique) => { return t.id === hoverTerm; });
                     if (currentTechnique !== undefined) {
                         hover = new vscode.Hover(buildTechniqueDescription(currentTechnique), hoverRange);
@@ -185,7 +181,7 @@ export class TechniqueHoverProvider implements vscode.HoverProvider {
                 resolve(hover);
             });
         } catch (error) {
-            output.appendLine(`provideHover error: ${error}`);
+            log(`TechniqueHoverProvider error: ${error}`);
         }
     }
 }
@@ -200,6 +196,7 @@ export class TechniqueCompletionProvider implements vscode.CompletionItemProvide
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
+                    if (debug) { log('Technique completion provider cancelled!'); }
                     resolve(undefined);
                 });
                 let completionItems: Array<vscode.CompletionItem> = new Array<vscode.CompletionItem>();
@@ -208,36 +205,27 @@ export class TechniqueCompletionProvider implements vscode.CompletionItemProvide
                 // ... only the numbers after the dot would be completed
                 const completionRange: vscode.Range | undefined = document.getWordRangeAtPosition(position, /\S+/);
                 if (completionRange === undefined) {
-                    dbgMsg = `TechniqueCompletionProvider: No completion item range provided. Returning everything`;
-                    console.log(dbgMsg);
-                    if (debug) { output.appendLine(dbgMsg); }
+                    if (debug) { log('TechniqueCompletionProvider: No completion item range provided. Returning everything'); }
                     completionItems = techniqueCompletionItems;
                 }
                 else {
                     const completionTerm: string = document.getText(completionRange);
-                    dbgMsg = `TechniqueCompletionProvider: Completion term: ${completionTerm}`;
-                    console.log(dbgMsg);
-                    if (debug) { output.appendLine(dbgMsg); }
+                    if (debug) { log(`TechniqueCompletionProvider: Completion term: ${completionTerm}`); }
                     // if this is a short completion term, return every parsed technique without further action
                     if (completionTerm.length < minTermLength) {
-                        dbgMsg = `TechniqueCompletionProvider: Short completion term detected. Returning everything`;
-                        console.log(dbgMsg);
-                        if (debug) { output.appendLine(dbgMsg); }
+                        if (debug) { log('TechniqueCompletionProvider: Short completion term detected. Returning everything'); }
                         completionItems = techniqueCompletionItems;
                     }
                     // do not search technique descriptions if the TID matches a revoked technique
                     else if (this.revokedTechniques.find((t: Technique) => { return t.id === completionTerm.toUpperCase(); })) {
-                        console.log(`TechniqueCompletionProvider: Completion term '${completionTerm}' found in revoked techniques`);
-                        if (debug) { output.appendLine(`Completion term '${completionTerm}' found in revoked techniques`); }
+                        if (debug) { log(`Completion term '${completionTerm}' found in revoked techniques`); }
                         completionItems = new Array<vscode.CompletionItem>();
                     }
                     // if the user is trying to complete something that matches an exact technique ID, just return that one item
                     else {
                         const technique: Technique | undefined = this.techniques.find((t: Technique) => { return t.id === completionTerm.toUpperCase(); });
                         if (technique !== undefined) {
-                            dbgMsg = `TechniqueCompletionProvider: Found exact technique ID '${technique.id}'`;
-                            console.log(dbgMsg);
-                            if (debug) { output.appendLine(dbgMsg); }
+                            if (debug) { log(`TechniqueCompletionProvider: Found exact technique ID '${technique.id}'`); }
                             completionItems = [buildCompletionItem(technique.id, technique)];
                         }
                         else {
@@ -257,13 +245,11 @@ export class TechniqueCompletionProvider implements vscode.CompletionItemProvide
                         // if at this point we still don't know what the user is trying to complete, and the user manually invoked the completion
                         // ... search all the technique descriptions for matching keywords
                         if (completionItems.length === 0 && context.triggerKind === vscode.CompletionTriggerKind.Invoke) {
-                            console.log(`TechniqueCompletionProvider: Term '${completionTerm}' meets length threshold for description searching`);
+                            if (debug) { log(`TechniqueCompletionProvider: Term '${completionTerm}' meets length threshold for description searching`); }
                             completionItems = this.techniques.filter((t: Technique) => {
                                 return t.description.long.toLowerCase().includes(completionTerm.toLowerCase());
                             }).map<vscode.CompletionItem>((t: Technique) => {
-                                dbgMsg = `TechniqueCompletionProvider: Found matching technique description in '${t.id}: ${t.name}'`;
-                                console.log(dbgMsg);
-                                if (debug) { output.appendLine(dbgMsg); }
+                                if (debug) { log(`TechniqueCompletionProvider: Found matching technique description in '${t.id}: ${t.name}'`); }
                                 const item: vscode.CompletionItem = buildCompletionItem(`${completionTerm} (technique description)`, t);
                                 // always show the long description because that's what we're searching in
                                 const documentation: vscode.MarkdownString = buildTechniqueDescription(t, 'long');
@@ -283,11 +269,10 @@ export class TechniqueCompletionProvider implements vscode.CompletionItemProvide
                         }
                     }
                 }
-                console.log(`TechniqueCompletionProvider: Returning ${completionItems.length} items`);
                 resolve(completionItems);
             });
         } catch (error) {
-            output.appendLine(`TechniqueCompletionProvider error: ${error}`);
+            log(`TechniqueCompletionProvider error: ${error}`);
         }
     }
 
@@ -296,9 +281,10 @@ export class TechniqueCompletionProvider implements vscode.CompletionItemProvide
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
+                    if (debug) { log('Technique completion resolver cancelled!'); }
                     resolve(undefined);
                 });
-                // console.log(`resolveCompletionItem: Received completion item with label: ${item.label}`);
+                if (debug) { log(`TechniqueCompletionProvider: Resolving completion item for '${item.label}'`); }
                 item.keepWhitespace = true;
                 // some items will already have documentation filled out at creation time
                 // ... such as technique description items, because we cannot correlate them back to a technique at resolution
@@ -322,12 +308,13 @@ export class TechniqueCompletionProvider implements vscode.CompletionItemProvide
             });
         }
         catch (error) {
-            output.appendLine(`TechniqueCompletionProvider error: ${error}`);
+            log(`TechniqueCompletionProvider error: ${error}`);
         }
     }
 }
 
 export function register(filters: vscode.DocumentSelector, techniques: Array<Technique>): Array<vscode.Disposable> {
+    log('Registering providers for techniques');
     // hover provider
     const techniqueHovers: TechniqueHoverProvider = new TechniqueHoverProvider();
     techniqueHovers.techniques = techniques;

--- a/src/techniques.ts
+++ b/src/techniques.ts
@@ -164,7 +164,7 @@ export class TechniqueHoverProvider implements vscode.HoverProvider {
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
-                    if (debug) { log('Technique hover provider cancelled!'); }
+                    if (debug) { log('TechniqueHoverProvider: Task cancelled!'); }
                     resolve(undefined);
                 });
                 let hover: vscode.Hover | undefined = undefined;
@@ -197,7 +197,7 @@ export class TechniqueCompletionProvider implements vscode.CompletionItemProvide
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
-                    if (debug) { log('Technique completion provider cancelled!'); }
+                    if (debug) { log('TechniqueCompletionProvider: Task cancelled!'); }
                     resolve(undefined);
                 });
                 let completionItems: Array<vscode.CompletionItem> = new Array<vscode.CompletionItem>();
@@ -281,7 +281,7 @@ export class TechniqueCompletionProvider implements vscode.CompletionItemProvide
             return new Promise((resolve) => {
                 token.onCancellationRequested(() => {
                     // if this process is cancelled, just return nothing
-                    if (debug) { log('Technique completion resolver cancelled!'); }
+                    if (debug) { log('TechniqueCompletionProvider: Resolution task cancelled!'); }
                     resolve(undefined);
                 });
                 if (debug) { log(`TechniqueCompletionProvider: Resolving completion item for '${item.label}'`); }

--- a/src/techniques.ts
+++ b/src/techniques.ts
@@ -175,6 +175,7 @@ export class TechniqueHoverProvider implements vscode.HoverProvider {
                     const hoverTerm: string = document.getText(hoverRange);
                     const currentTechnique: Technique | undefined = this.techniques.find((t: Technique) => { return t.id === hoverTerm; });
                     if (currentTechnique !== undefined) {
+                        if (debug) { log(`TechniqueHoverProvider: Found exact Technique ID '${currentTechnique.id}'`); }
                         hover = new vscode.Hover(buildTechniqueDescription(currentTechnique), hoverRange);
                     }
                 }
@@ -200,7 +201,6 @@ export class TechniqueCompletionProvider implements vscode.CompletionItemProvide
                     resolve(undefined);
                 });
                 let completionItems: Array<vscode.CompletionItem> = new Array<vscode.CompletionItem>();
-                let dbgMsg = '';
                 // without the regex, if a user tries to complete a subtechnique
                 // ... only the numbers after the dot would be completed
                 const completionRange: vscode.Range | undefined = document.getWordRangeAtPosition(position, /\S+/);
@@ -210,7 +210,6 @@ export class TechniqueCompletionProvider implements vscode.CompletionItemProvide
                 }
                 else {
                     const completionTerm: string = document.getText(completionRange);
-                    if (debug) { log(`TechniqueCompletionProvider: Completion term: ${completionTerm}`); }
                     // if this is a short completion term, return every parsed technique without further action
                     if (completionTerm.length < minTermLength) {
                         if (debug) { log('TechniqueCompletionProvider: Short completion term detected. Returning everything'); }
@@ -218,14 +217,14 @@ export class TechniqueCompletionProvider implements vscode.CompletionItemProvide
                     }
                     // do not search technique descriptions if the TID matches a revoked technique
                     else if (this.revokedTechniques.find((t: Technique) => { return t.id === completionTerm.toUpperCase(); })) {
-                        if (debug) { log(`Completion term '${completionTerm}' found in revoked techniques`); }
+                        if (debug) { log(`TechniqueCompletionProvider: Completion term '${completionTerm}' found in revoked techniques`); }
                         completionItems = new Array<vscode.CompletionItem>();
                     }
                     // if the user is trying to complete something that matches an exact technique ID, just return that one item
                     else {
                         const technique: Technique | undefined = this.techniques.find((t: Technique) => { return t.id === completionTerm.toUpperCase(); });
                         if (technique !== undefined) {
-                            if (debug) { log(`TechniqueCompletionProvider: Found exact technique ID '${technique.id}'`); }
+                            if (debug) { log(`TechniqueCompletionProvider: Found exact Technique ID '${technique.id}'`); }
                             completionItems = [buildCompletionItem(technique.id, technique)];
                         }
                         else {
@@ -238,6 +237,7 @@ export class TechniqueCompletionProvider implements vscode.CompletionItemProvide
                             });
                             if (possibleTechniques !== undefined) {
                                 completionItems = possibleTechniques.map<vscode.CompletionItem>((t: Technique) => {
+                                    if (debug) { log(`TechniqueCompletionProvider: Found possible Technique '${t.name}'`); }
                                     return buildCompletionItem(t.name, t);
                                 });
                             }
@@ -314,7 +314,7 @@ export class TechniqueCompletionProvider implements vscode.CompletionItemProvide
 }
 
 export function register(filters: vscode.DocumentSelector, techniques: Array<Technique>): Array<vscode.Disposable> {
-    log('Registering providers for techniques');
+    log('Registering providers for Techniques');
     // hover provider
     const techniqueHovers: TechniqueHoverProvider = new TechniqueHoverProvider();
     techniqueHovers.techniques = techniques;


### PR DESCRIPTION
* Created new helper: `log()` - this sends a given message to the output channel prepended with an ISO timestamp
* Updated all instances of `output.appendLine()` to use the new helper instead
* Aligned provider log messages and circumstances in which each provider submits a log (each provider prepends its own name to debug log messages)
* Removed all usage of `console.log` except in extension tests
* Added debug log messages to all provider cancellations to aid in debugging when tasks are repeatedly cancelled
* Improved log messages in `cacheData()` function to aid users unable to download the ATT&CK files on startup (issue #5)
