### PR TITLE
New command: insertLink

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
     "requires": true,
     "packages": {
         "": {
-            "version": "0.1.1",
+            "version": "1.0.0",
             "dependencies": {
                 "markdown-it": "^11.0.1"
             },
@@ -457,7 +457,6 @@
             "dependencies": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
-                "fsevents": "~2.1.1",
                 "glob-parent": "~5.1.0",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,16 @@
                     }
                 }
             }
-        ]
+        ],
+        "menus": {
+            "editor/context": [
+                {
+                    "when": "resourceLangId == markdown",
+                    "command": "vscode-attack.insertLink",
+                    "group": "ATT&CK"
+                }
+            ]
+        }
     },
     "activationEvents": [
         "onStartupFinished"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
                             "id",
                             "name",
                             "fullname",
+                            "link",
                             "id-name",
                             "id-fullname"
                         ],
@@ -61,6 +62,7 @@
                             "Insert just the ID of the completed item (e.g. 'T1059.001')",
                             "Insert just the name of the completed item (e.g. 'PowerShell')",
                             "Insert the name and parent name if the item is a subtechnique (e.g. 'Command and Scripting Interpreter: PowerShell')",
+                            "Insert a link to the ATT&CK website (e.g. 'https://attack.mitre.org/techniques/T1059/001')",
                             "Insert both the ID and the name of the completed item (e.g. 'T1059.001 PowerShell')",
                             "Insert the ID, name, and parent name if the item is a subtechnique (e.g. 'T1059.001 Command and Scripting Interpreter: PowerShell')"
                         ]

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
             {
                 "command": "vscode-attack.search",
                 "title": "ATT&CK: Search ATT&CK Techniques"
+            },
+            {
+                "command": "vscode-attack.insertLink",
+                "title": "ATT&CK: Insert link to ATT&CK website"
             }
         ],
         "configuration": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import { init as initSoftware, register as registerSoftware } from './software';
 import { init as initTactics, register as registerTactics } from './tactics';
 import { init as initTechniques, register as registerTechniques } from './techniques';
 import { search } from './search';
+import { insertLink } from './insertLink';
 
 
 // track the providers we have so we can recreate them in case applicableFiles gets updated or they get toggled
@@ -179,6 +180,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<Record
         }));
         // commands
         context.subscriptions.push(vscode.commands.registerCommand('vscode-attack.search', () => { search(techniques); }));
+        context.subscriptions.push(vscode.commands.registerCommand('vscode-attack.insertLink', () => {
+            const editor: vscode.TextEditor|undefined = vscode.window.activeTextEditor;
+            insertLink(editor, groups, mitigations, software, tactics, techniques);
+        }));
         // window
         const statusBarItem: vscode.StatusBarItem|undefined = await createStatusBar(context.globalStorageUri.fsPath);
         if (statusBarItem !== undefined) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -185,7 +185,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Record
         if (debug) { log('Registered command: vscode-attack.search'); }
         context.subscriptions.push(vscode.commands.registerCommand('vscode-attack.insertLink', () => {
             const editor: vscode.TextEditor|undefined = vscode.window.activeTextEditor;
-            insertLink(editor, groups, mitigations, software, tactics, techniques);
+            // assume the user does not want to use links to revoked techniques, which will be redirected
+            // ... to the current technique on the site anyway
+            insertLink(editor, groups, mitigations, software, tactics, helpers.getCurrentTechniques(techniques));
         }));
         if (debug) { log('Registered command: vscode-attack.insertLink'); }
         // window

--- a/src/groups.ts
+++ b/src/groups.ts
@@ -14,6 +14,9 @@ function buildInsertionText(group: Group): string {
     else if (completionFormat === 'name' || completionFormat === 'fullname') {
         insertionText = group.name;
     }
+    else if (completionFormat === 'link') {
+        insertionText = group.url;
+    }
     return insertionText;
 }
 

--- a/src/insertLink.ts
+++ b/src/insertLink.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { configSection, debug } from './configuration';
-import { output } from './helpers';
+import { log } from './helpers';
 
 
 /*
@@ -20,22 +20,22 @@ export function insertLink(editor: vscode.TextEditor|undefined, groups: Array<Gr
                            tactics: Array<Tactic>=[], techniques: Array<Technique>=[]): void {
     if (editor === undefined) {
         // there's no open text document, so there couldn't possibly be highlighted text
-        if (debug) { output.appendLine('insertLink: Could not identify an active editor, so no text can be inserted.'); }
+        if (debug) { log('insertLink: Could not identify an active editor, so no text can be inserted.'); }
         vscode.window.showWarningMessage('ATT&CK: Could not insert a link, because there is no active text document.');
     }
     else {
-        if (debug) { output.appendLine(`insertLink: Getting currently highlighted text`); }
+        if (debug) { log(`insertLink: Getting currently highlighted text`); }
         const currentSelection: vscode.Selection|undefined = editor.selection;
         if (currentSelection === undefined || currentSelection.isEmpty) {
             // we don't actually have text to replace
             // ... this might happen if this command was called without highlighting text first
-            if (debug) { output.appendLine(`insertLink: No text has been selected. Cannot insert link`); }
+            if (debug) { log(`insertLink: No text has been selected. Cannot insert link`); }
             vscode.window.showWarningMessage('ATT&CK: Could not insert a link, because no text was selected.');
         }
         else {
             const highlightedText = editor.document.getText(currentSelection);
             const trimmedText = highlightedText.trimRight();
-            if (debug) { output.appendLine(`insertLink: Text to insert a link for: '${trimmedText}'`); }
+            if (debug) { log(`insertLink: Text to insert a link for: '${trimmedText}'`); }
             const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(configSection);
             let matchingObject: Group|Mitigation|Software|Tactic|Technique|undefined = undefined;
             // search all ATT&CK types for the first matching ID
@@ -56,7 +56,7 @@ export function insertLink(editor: vscode.TextEditor|undefined, groups: Array<Gr
             }
             if (matchingObject === undefined) {
                 // doesn't look like the highlighted text resembles any ATT&CK object we're aware of
-                if (debug) { output.appendLine(`insertLink: Did not find a matching object for '${trimmedText}'`); }
+                if (debug) { log(`insertLink: Did not find a matching object for '${trimmedText}'`); }
                 vscode.window.showWarningMessage(`ATT&CK: Could not insert a link, because '${trimmedText.substr(0, 20)}' does not match any available ATT&CK objects.`);
                 return;
             }
@@ -64,13 +64,13 @@ export function insertLink(editor: vscode.TextEditor|undefined, groups: Array<Gr
             if (link === undefined) {
                 // we should never get here since we should've detected malformed ATT&CK objects on startup
                 // ... but still, let's try to inform the user if something weird happens
-                output.appendLine(`insertLink: Could not extract URL for ${matchingObject.id}!`);
+                log(`insertLink: Could not extract URL for ${matchingObject.id}!`);
                 vscode.window.showErrorMessage(`ATT&CK: An error occurred while attempting to insert a link - no associated URL found for ${matchingObject.id}!`);
             }
             else {
                 // and we're finally at the point where a link can be inserted
                 editor.edit((editBuilder: vscode.TextEditorEdit) => {
-                    if (debug) { output.appendLine(`insertLink: Found a matching object. Inserting the following text: '${link}'`); }
+                    if (debug) { log(`insertLink: Found a matching object. Inserting the following text: '${link}'`); }
                     if (trimmedText !== highlightedText) {
                         // append extra whitespace if there is any
                         editBuilder.replace(currentSelection, link + highlightedText.replace(trimmedText, ''));

--- a/src/insertLink.ts
+++ b/src/insertLink.ts
@@ -25,61 +25,72 @@ export function insertLink(editor: vscode.TextEditor|undefined, groups: Array<Gr
     }
     else {
         if (debug) { log(`insertLink: Getting currently highlighted text`); }
-        const currentSelection: vscode.Selection|undefined = editor.selection;
-        if (currentSelection === undefined || currentSelection.isEmpty) {
-            // we don't actually have text to replace
-            // ... this might happen if this command was called without highlighting text first
-            if (debug) { log(`insertLink: No text has been selected. Cannot insert link`); }
+        let currentSelection: vscode.Selection = editor.selection;
+        // user isn't highlighting anything - just has a cursor pointed at something
+        if (currentSelection.isEmpty) {
+            // Need to match all ATT&CK IDs generically, including sub-techniques, hence the period
+            // ... only matches 1 word - if the user needs to insert a link for multiple words (e.g. 'OS Credential Dumping')
+            // ... then they will need to highlight the entire term
+            const wordMatcher: RegExp = /[a-zA-Z0-9.]+/;
+            const cursorRange: vscode.Range|undefined = editor.document.getWordRangeAtPosition(currentSelection.active, wordMatcher);
+            // if cursorRange is undefined, most likely the selected text is not a word
+            // ... in this case, just carry through and let the highlightedText remain undefined
+            if (cursorRange !== undefined) {
+                currentSelection = new vscode.Selection(cursorRange.start, cursorRange.end);
+            }
+        }
+        const highlightedText: string|undefined = editor.document.getText(currentSelection);
+        if (highlightedText === undefined) {
+            log(`insertLink: No text has been selected. Cannot insert link`);
             vscode.window.showWarningMessage('ATT&CK: Could not insert a link, because no text was selected.');
+            return;
+        }
+        // text was found, now to figure out which ATT&CK object it identifies
+        const trimmedText = highlightedText.trimRight();
+        if (debug) { log(`insertLink: Text to insert a link for: '${trimmedText}'`); }
+        const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(configSection);
+        let matchingObject: Group|Mitigation|Software|Tactic|Technique|undefined = undefined;
+        // search all ATT&CK types for the first matching ID
+        if (matchingObject === undefined && configuration.get('groups')) {
+            matchingObject = groups.find((g: Group) => { return g.id === trimmedText; });
+        }
+        if (matchingObject === undefined && configuration.get('mitigations')) {
+            matchingObject = mitigations.find((m: Mitigation) => { return m.id === trimmedText; });
+        }
+        if (matchingObject === undefined && configuration.get('software')) {
+            matchingObject = software.find((s: Software) => { return s.id === trimmedText; });
+        }
+        if (matchingObject === undefined && configuration.get('tactics')) {
+            matchingObject = tactics.find((t: Tactic) => { return t.id === trimmedText; });
+        }
+        if (matchingObject === undefined && configuration.get('techniques')) {
+            matchingObject = techniques.find((t: Technique) => { return t.id === trimmedText; });
+        }
+        if (matchingObject === undefined) {
+            // doesn't look like the highlighted text resembles any ATT&CK object we're aware of
+            if (debug) { log(`insertLink: Did not find a matching object for '${trimmedText}'`); }
+            vscode.window.showWarningMessage(`ATT&CK: Could not insert a link, because '${trimmedText.substr(0, 20)}' does not match any available ATT&CK objects.`);
+            return;
+        }
+        const link: string|undefined = generateLink(trimmedText, matchingObject.url);
+        if (link === undefined) {
+            // we should never get here since we should've detected malformed ATT&CK objects on startup
+            // ... but still, let's try to inform the user if something weird happens
+            log(`insertLink: Could not extract URL for ${trimmedText}!`);
+            vscode.window.showErrorMessage(`ATT&CK: An error occurred while attempting to insert a link - no associated URL found for ${trimmedText}!`);
         }
         else {
-            const highlightedText = editor.document.getText(currentSelection);
-            const trimmedText = highlightedText.trimRight();
-            if (debug) { log(`insertLink: Text to insert a link for: '${trimmedText}'`); }
-            const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(configSection);
-            let matchingObject: Group|Mitigation|Software|Tactic|Technique|undefined = undefined;
-            // search all ATT&CK types for the first matching ID
-            if (matchingObject === undefined && configuration.get('groups')) {
-                matchingObject = groups.find((g: Group) => { return g.id === trimmedText; });
-            }
-            if (matchingObject === undefined && configuration.get('mitigations')) {
-                matchingObject = mitigations.find((m: Mitigation) => { return m.id === trimmedText; });
-            }
-            if (matchingObject === undefined && configuration.get('software')) {
-                matchingObject = software.find((s: Software) => { return s.id === trimmedText; });
-            }
-            if (matchingObject === undefined && configuration.get('tactics')) {
-                matchingObject = tactics.find((t: Tactic) => { return t.id === trimmedText; });
-            }
-            if (matchingObject === undefined && configuration.get('techniques')) {
-                matchingObject = techniques.find((t: Technique) => { return t.id === trimmedText; });
-            }
-            if (matchingObject === undefined) {
-                // doesn't look like the highlighted text resembles any ATT&CK object we're aware of
-                if (debug) { log(`insertLink: Did not find a matching object for '${trimmedText}'`); }
-                vscode.window.showWarningMessage(`ATT&CK: Could not insert a link, because '${trimmedText.substr(0, 20)}' does not match any available ATT&CK objects.`);
-                return;
-            }
-            const link: string|undefined = generateLink(trimmedText, matchingObject.url);
-            if (link === undefined) {
-                // we should never get here since we should've detected malformed ATT&CK objects on startup
-                // ... but still, let's try to inform the user if something weird happens
-                log(`insertLink: Could not extract URL for ${matchingObject.id}!`);
-                vscode.window.showErrorMessage(`ATT&CK: An error occurred while attempting to insert a link - no associated URL found for ${matchingObject.id}!`);
-            }
-            else {
-                // and we're finally at the point where a link can be inserted
-                editor.edit((editBuilder: vscode.TextEditorEdit) => {
-                    if (debug) { log(`insertLink: Found a matching object. Inserting the following text: '${link}'`); }
-                    if (trimmedText !== highlightedText) {
-                        // append extra whitespace if there is any
-                        editBuilder.replace(currentSelection, link + highlightedText.replace(trimmedText, ''));
-                    }
-                    else {
-                        editBuilder.replace(currentSelection, link);
-                    }
-                });
-            }
+            // and we're finally at the point where a link can be inserted
+            editor.edit((editBuilder: vscode.TextEditorEdit) => {
+                if (debug) { log(`insertLink: Found a matching object. Inserting the following text: '${link}'`); }
+                if (highlightedText !== trimmedText) {
+                    // append extra whitespace if there is any
+                    editBuilder.replace(currentSelection, link + highlightedText.replace(trimmedText, ''));
+                }
+                else {
+                    editBuilder.replace(currentSelection, link);
+                }
+            });
         }
     }
 }

--- a/src/insertLink.ts
+++ b/src/insertLink.ts
@@ -52,19 +52,19 @@ export function insertLink(editor: vscode.TextEditor|undefined, groups: Array<Gr
         let matchingObject: Group|Mitigation|Software|Tactic|Technique|undefined = undefined;
         // search all ATT&CK types for the first matching ID
         if (matchingObject === undefined && configuration.get('groups')) {
-            matchingObject = groups.find((g: Group) => { return g.id === trimmedText; });
+            matchingObject = groups.find((g: Group) => { return g.id === trimmedText || g.name === trimmedText; });
         }
         if (matchingObject === undefined && configuration.get('mitigations')) {
-            matchingObject = mitigations.find((m: Mitigation) => { return m.id === trimmedText; });
+            matchingObject = mitigations.find((m: Mitigation) => { return m.id === trimmedText || m.name === trimmedText; });
         }
         if (matchingObject === undefined && configuration.get('software')) {
-            matchingObject = software.find((s: Software) => { return s.id === trimmedText; });
+            matchingObject = software.find((s: Software) => { return s.id === trimmedText || s.name === trimmedText; });
         }
         if (matchingObject === undefined && configuration.get('tactics')) {
-            matchingObject = tactics.find((t: Tactic) => { return t.id === trimmedText; });
+            matchingObject = tactics.find((t: Tactic) => { return t.id === trimmedText || t.name === trimmedText; });
         }
         if (matchingObject === undefined && configuration.get('techniques')) {
-            matchingObject = techniques.find((t: Technique) => { return t.id === trimmedText; });
+            matchingObject = techniques.find((t: Technique) => { return t.id === trimmedText || t.name === trimmedText; });
         }
         if (matchingObject === undefined) {
             // doesn't look like the highlighted text resembles any ATT&CK object we're aware of

--- a/src/insertLink.ts
+++ b/src/insertLink.ts
@@ -1,0 +1,83 @@
+import * as vscode from 'vscode';
+import { configSection, debug } from './configuration';
+import { output } from './helpers';
+
+
+/*
+    Generate the appropriate link format based on the current editor's file type
+    Currently only supports Markdown links, but more may be added in the future
+*/
+function generateLink(text: string, url: string): string|undefined {
+    let link: string|undefined = undefined;
+    if (vscode.window.activeTextEditor?.document.languageId === 'markdown') {
+        link = `[${text}](${url})`;
+    }
+    return link;
+}
+
+export function insertLink(editor: vscode.TextEditor|undefined, groups: Array<Group>=[],
+                           mitigations: Array<Mitigation>=[], software: Array<Software>=[],
+                           tactics: Array<Tactic>=[], techniques: Array<Technique>=[]): void {
+    if (editor === undefined) {
+        // there's no open text document, so there couldn't possibly be highlighted text
+        if (debug) { output.appendLine('insertLink: Could not identify an active editor, so no text can be inserted.'); }
+        console.log('insertLink: No activeTextEditor found. Could not identify a text selection as a result');
+        vscode.window.showWarningMessage('ATT&CK: Could not insert a link, because there is no active text document.');
+    }
+    else {
+        if (debug) { output.appendLine(`insertLink: Getting currently highlighted text`); }
+        const currentSelection: vscode.Selection|undefined = editor.selection;
+        if (currentSelection === undefined || currentSelection.isEmpty) {
+            // we don't actually have text to replace
+            // ... this might happen if this command was called without highlighting text first
+            if (debug) { output.appendLine(`insertLink: No text has been selected. Cannot insert link`); }
+            console.log('insertLink: Empty selection identified. Cannot insert link');
+            vscode.window.showWarningMessage('ATT&CK: Could not insert a link, because no text was selected.');
+        }
+        else {
+            const highlightedText = editor.document.getText(currentSelection).trim();
+            if (debug) { output.appendLine(`insertLink: Text to insert a link for: '${highlightedText}'`); }
+            const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(configSection);
+            let matchingObject: Group|Mitigation|Software|Tactic|Technique|undefined = undefined;
+            // search all ATT&CK types for the first matching ID
+            if (matchingObject === undefined && configuration.get('groups')) {
+                matchingObject = groups.find((g: Group) => { return g.id === highlightedText; });
+            }
+            if (matchingObject === undefined && configuration.get('mitigations')) {
+                matchingObject = mitigations.find((m: Mitigation) => { return m.id === highlightedText; });
+            }
+            if (matchingObject === undefined && configuration.get('software')) {
+                matchingObject = software.find((s: Software) => { return s.id === highlightedText; });
+            }
+            if (matchingObject === undefined && configuration.get('tactics')) {
+                matchingObject = tactics.find((t: Tactic) => { return t.id === highlightedText; });
+            }
+            if (matchingObject === undefined && configuration.get('techniques')) {
+                matchingObject = techniques.find((t: Technique) => { return t.id === highlightedText; });
+            }
+            if (matchingObject === undefined) {
+                // doesn't look like the highlighted text resembles any ATT&CK object we're aware of
+                if (debug) { output.appendLine(`insertLink: Did not find a matching object for '${highlightedText}'`); }
+                console.log(`insertLink: Did not find a matching object for '${highlightedText}'`);
+                vscode.window.showWarningMessage(`ATT&CK: Could not insert a link, because '${highlightedText.substr(0, 20)}' does not match any available ATT&CK objects.`);
+                return;
+            }
+            const link: string|undefined = generateLink(highlightedText, matchingObject.url);
+            if (link === undefined) {
+                // we should never get here since we should've detected malformed ATT&CK objects on startup
+                // ... but still, let's try to inform the user if something weird happens
+                output.appendLine(`insertLink: Could not extract URL for ${matchingObject.id}!`);
+                console.log(`insertLink: ATT&CK object has no 'url' attribute to extract! ${JSON.stringify(matchingObject)}`);
+                vscode.window.showErrorMessage(`ATT&CK: An error occurred while attempting to insert a link - no associated URL found for ${matchingObject.id}!`);
+            }
+            else {
+                // and we're finally at the point where a link can be inserted
+                editor.edit((editBuilder: vscode.TextEditorEdit) => {
+                    if (debug) { output.appendLine(`insertLink: Found a matching object. Inserting the following text: '${link}'`); }
+                    console.log(`insertLink: Found a matching object. Inserting the following text: '${link}'`);
+                    editBuilder.replace(currentSelection, link);
+                });
+            }
+        }
+    }
+}

--- a/src/insertLink.ts
+++ b/src/insertLink.ts
@@ -21,7 +21,6 @@ export function insertLink(editor: vscode.TextEditor|undefined, groups: Array<Gr
     if (editor === undefined) {
         // there's no open text document, so there couldn't possibly be highlighted text
         if (debug) { output.appendLine('insertLink: Could not identify an active editor, so no text can be inserted.'); }
-        console.log('insertLink: No activeTextEditor found. Could not identify a text selection as a result');
         vscode.window.showWarningMessage('ATT&CK: Could not insert a link, because there is no active text document.');
     }
     else {
@@ -31,7 +30,6 @@ export function insertLink(editor: vscode.TextEditor|undefined, groups: Array<Gr
             // we don't actually have text to replace
             // ... this might happen if this command was called without highlighting text first
             if (debug) { output.appendLine(`insertLink: No text has been selected. Cannot insert link`); }
-            console.log('insertLink: Empty selection identified. Cannot insert link');
             vscode.window.showWarningMessage('ATT&CK: Could not insert a link, because no text was selected.');
         }
         else {
@@ -58,7 +56,6 @@ export function insertLink(editor: vscode.TextEditor|undefined, groups: Array<Gr
             if (matchingObject === undefined) {
                 // doesn't look like the highlighted text resembles any ATT&CK object we're aware of
                 if (debug) { output.appendLine(`insertLink: Did not find a matching object for '${highlightedText}'`); }
-                console.log(`insertLink: Did not find a matching object for '${highlightedText}'`);
                 vscode.window.showWarningMessage(`ATT&CK: Could not insert a link, because '${highlightedText.substr(0, 20)}' does not match any available ATT&CK objects.`);
                 return;
             }
@@ -67,14 +64,12 @@ export function insertLink(editor: vscode.TextEditor|undefined, groups: Array<Gr
                 // we should never get here since we should've detected malformed ATT&CK objects on startup
                 // ... but still, let's try to inform the user if something weird happens
                 output.appendLine(`insertLink: Could not extract URL for ${matchingObject.id}!`);
-                console.log(`insertLink: ATT&CK object has no 'url' attribute to extract! ${JSON.stringify(matchingObject)}`);
                 vscode.window.showErrorMessage(`ATT&CK: An error occurred while attempting to insert a link - no associated URL found for ${matchingObject.id}!`);
             }
             else {
                 // and we're finally at the point where a link can be inserted
                 editor.edit((editBuilder: vscode.TextEditorEdit) => {
                     if (debug) { output.appendLine(`insertLink: Found a matching object. Inserting the following text: '${link}'`); }
-                    console.log(`insertLink: Found a matching object. Inserting the following text: '${link}'`);
                     editBuilder.replace(currentSelection, link);
                 });
             }

--- a/src/mitigations.ts
+++ b/src/mitigations.ts
@@ -14,6 +14,9 @@ function buildInsertionText(tool: Mitigation): string {
     else if (completionFormat === 'name' || completionFormat === 'fullname') {
         insertionText = tool.name;
     }
+    else if (completionFormat === 'link') {
+        insertionText = tool.url;
+    }
     return insertionText;
 }
 

--- a/src/software.ts
+++ b/src/software.ts
@@ -14,6 +14,9 @@ function buildInsertionText(tool: Software): string {
     else if (completionFormat === 'name' || completionFormat === 'fullname') {
         insertionText = tool.name;
     }
+    else if (completionFormat === 'link') {
+        insertionText = tool.url;
+    }
     return insertionText;
 }
 

--- a/src/tactics.ts
+++ b/src/tactics.ts
@@ -13,6 +13,9 @@ function buildInsertionText(tactic: Tactic): string {
     else if (completionFormat === 'name' || completionFormat === 'fullname') {
         insertionText = tactic.name;
     }
+    else if (completionFormat === 'link') {
+        insertionText = tactic.url;
+    }
     return insertionText;
 }
 

--- a/src/techniques.ts
+++ b/src/techniques.ts
@@ -15,6 +15,9 @@ function buildInsertionText(technique: Technique): string {
     else if (completionFormat === 'name') {
         insertionText = technique.name;
     }
+    else if (completionFormat === 'link') {
+        insertionText = technique.url;
+    }
     else if (completionFormat === 'fullname') {
         // only apply this format when the technique has a parent
         if (technique.parent !== undefined) {

--- a/src/test/files/links.md
+++ b/src/test/files/links.md
@@ -1,0 +1,5 @@
+T1059
+T1059.001
+PowerShell
+certutil
+TA0002

--- a/src/test/suite/commands.test.ts
+++ b/src/test/suite/commands.test.ts
@@ -128,4 +128,19 @@ describe('Command: insertLink', function () {
         const result: vscode.TextLine = editor.document.lineAt(highlightedText.active.line);
         assert.ok(!result.text.includes(unExpectedLink));
     });
+    it('should preserve newlines when present', async function () {
+        const expectedLink: string = attackObjects[0].url + '\n';
+        const highlightedText: vscode.Selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(2, 0));
+        let editor: vscode.TextEditor = await vscode.window.showTextDocument(testUri);
+        editor.selections = [highlightedText];
+        console.log(`highlighted text: '${editor.document.getText(editor.selection)}'`);
+        vscode.commands.executeCommand('vscode-attack.insertLink', editor, {techniques: attackObjects});
+        // close and reopen to get our new document text
+        vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+        editor = await vscode.window.showTextDocument(testUri);
+        console.log(editor.document.getText());
+        const result: vscode.TextLine = editor.document.lineAt(highlightedText.active.line);
+        console.log(`result: '${result.text}'`);
+        assert.ok(result.text.includes(expectedLink));
+    });
 });

--- a/src/test/suite/commands.test.ts
+++ b/src/test/suite/commands.test.ts
@@ -105,7 +105,7 @@ describe('Command: insertLink', function () {
         const commands: Array<string> = await vscode.commands.getCommands(true);
         assert.ok(commands.includes(insertLinkCommand), `No '${insertLinkCommand}' exists.`);
     });
-    it('should insert a link for markdown text', async function () {
+    it('should insert a link for ATT&CK object IDs', async function () {
         const expectedMarkdown: string = `[${attackObjects[0].id}](${attackObjects[0].url})`;
         const tid: string = attackObjects[0].id;
         const highlightedText: vscode.Selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, tid.length));
@@ -118,9 +118,25 @@ describe('Command: insertLink', function () {
         const result: vscode.TextLine = editor.document.lineAt(highlightedText.active.line);
         assert.strictEqual(result.text, expectedMarkdown);
     });
+    it('should insert a link for ATT&CK object names', async function () {
+        const expectedMarkdown: string = `[${attackObjects[0].name}](${attackObjects[0].url})`;
+        const name: string = attackObjects[0].name;
+        const highlightedText: vscode.Selection = new vscode.Selection(new vscode.Position(2, 0), new vscode.Position(2, name.length));
+        let editor: vscode.TextEditor = await vscode.window.showTextDocument(testUri);
+        editor.selections = [highlightedText];
+        vscode.commands.executeCommand('vscode-attack.insertLink', editor, {techniques: attackObjects});
+        // console.log(editor.document.getText());
+        // close and reopen to get our new document text
+        vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+        // console.log('----');
+        // console.log(editor.document.getText());
+        editor = await vscode.window.showTextDocument(testUri);
+        const result: vscode.TextLine = editor.document.lineAt(highlightedText.active.line);
+        assert.strictEqual(result.text, expectedMarkdown);
+    });
     it('should do nothing when highlighted text is not an ATT&CK object ID', async function () {
-        const text: string = attackObjects[0].name;
-        const highlightedText: vscode.Selection = new vscode.Selection(new vscode.Position(2, 0), new vscode.Position(2, text.length));
+        const text: string = 'certutil';
+        const highlightedText: vscode.Selection = new vscode.Selection(new vscode.Position(3, 0), new vscode.Position(3, text.length));
         const editor: vscode.TextEditor|undefined = await vscode.window.showTextDocument(testUri);
         editor.selections = [highlightedText];
         vscode.commands.executeCommand('vscode-attack.insertLink', editor, {techniques: attackObjects});

--- a/src/test/suite/commands.test.ts
+++ b/src/test/suite/commands.test.ts
@@ -1,0 +1,72 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as search from '../../search';
+import { disposables, extensionID, ignoreConsoleLogs, resetState } from '../suite/testHelpers';
+
+
+describe('Search Command', function () {
+    const searchCommand = 'vscode-attack.search';
+    let ext: vscode.Extension<unknown> | undefined;
+
+    before(async function () {
+        ext = vscode.extensions.getExtension(extensionID);
+        await ext?.activate();
+        exports = ext?.exports;
+    });
+    beforeEach(ignoreConsoleLogs);
+    afterEach(resetState);
+    it('search command should exist', function () {
+        vscode.commands.getCommands(true).then((commands: string[]) => {
+            assert.ok(commands.includes(searchCommand), `No '${searchCommand}' exists.`);
+        });
+    });
+    it('should open one webpanel for exact TIDs', function () {
+        const tid = 'T1059.001';
+        const expectedTitle = `${tid}: PowerShell`;
+        search.search(exports.getAllTechniques(), tid).then((panels: Array<vscode.WebviewPanel>) => {
+            panels.forEach((panel: vscode.WebviewPanel) => { disposables.push(panel); });
+            assert.strictEqual(panels.length, 1);
+            assert.strictEqual(panels[0].title, expectedTitle);
+        });
+    });
+    it('should open one webpanel for revoked TIDs', async function () {
+        const tid = 'T1086';
+        const expectedTitle = `${tid}: PowerShell`;
+        const expectedText = `<h3>PowerShell (REVOKED)</h3>`;
+        search.search(exports.getAllTechniques(), tid).then((panels: Array<vscode.WebviewPanel>) => {
+            panels.forEach((panel: vscode.WebviewPanel) => { disposables.push(panel); });
+            assert.strictEqual(panels.length, 1);
+            assert.strictEqual(panels[0].title, expectedTitle);
+            assert.ok(panels[0].webview.html.includes(expectedText));
+        });
+    });
+    it('should open all webpanels containing a technique name', async function () {
+        const name = 'PowerShell';
+        // Should return both 'PowerShell' and 'PowerShell Profile'
+        const expectedTitles: Array<string> = ['T1059.001: PowerShell', 'T1546.013: PowerShell Profile'];
+        search.search(exports.getAllTechniques(), name).then((panels: Array<vscode.WebviewPanel>) => {
+            panels.forEach((panel: vscode.WebviewPanel) => { disposables.push(panel); });
+            assert.strictEqual(panels.length, 2);
+            const titles: Array<string> = panels.map<string>((panel: vscode.WebviewPanel) => { return panel.title; });
+            assert.deepStrictEqual(titles, expectedTitles);
+        });
+    });
+    it('should open all webpanels for lengthy terms in technique descriptions', async function () {
+        // this term is not a technique ID or in any technique name
+        // so the only way it would return an item is if the descriptions are searched
+        const term = 'certutil';
+        const expectedTitle = 'T1140: Deobfuscate/Decode Files or Information';
+        search.search(exports.getAllTechniques(), term).then((panels: Array<vscode.WebviewPanel>) => {
+            panels.forEach((panel: vscode.WebviewPanel) => { disposables.push(panel); });
+            assert.strictEqual(panels.length, 1);
+            assert.strictEqual(panels[0].title, expectedTitle);
+        });
+    });
+    it('should not search for short terms in technique descriptions', async function () {
+        const term = 'the';
+        search.search(exports.getAllTechniques(), term).then((panels: Array<vscode.WebviewPanel>) => {
+            panels.forEach((panel: vscode.WebviewPanel) => { disposables.push(panel); });
+            assert.strictEqual(panels.length, 0);
+        });
+    });
+});

--- a/src/test/suite/commands.test.ts
+++ b/src/test/suite/commands.test.ts
@@ -139,7 +139,8 @@ describe('Command: insertLink', function () {
         const result: vscode.TextLine = editor.document.lineAt(highlightedText.anchor.line);
         assert.strictEqual(result.text, expectedMarkdown);
     });
-    it('should identify ATT&CK objects without highlighting text', async function () {
+    it.skip('should identify ATT&CK objects without highlighting text', async function () {
+        // may keep this idea, may not
         const expectedMarkdown: string = `[${attackObjects[0].id}](${attackObjects[0].url})`;
         const tid: string = attackObjects[0].id;
         const cursor: vscode.Position = new vscode.Position(1, tid.length-1);

--- a/src/test/suite/commands.test.ts
+++ b/src/test/suite/commands.test.ts
@@ -75,7 +75,7 @@ describe('Command: search', function () {
 describe('Command: insertLink', function () {
     const events: Array<vscode.Disposable> = [];
     const insertLinkCommand = 'vscode-attack.insertLink';
-    const testPath: string = path.resolve(__dirname, '..', '..', '..', 'src', 'test', 'files', 'test.md');
+    const testPath: string = path.resolve(__dirname, '..', '..', '..', 'src', 'test', 'files', 'links.md');
     const testUri: vscode.Uri = vscode.Uri.file(testPath);
     let ext: vscode.Extension<unknown> | undefined;
     const attackObjects: Array<Group|Mitigation|Software|Tactic|Technique> = [
@@ -154,7 +154,7 @@ describe('Command: insertLink', function () {
     });
     it('should preserve trailing whitespace when present', function (done) {
         const expectedMarkdown: string = `[TA0002](https://attack.mitre.org/tactics/TA0002)`;
-        const highlightedText: vscode.Selection = new vscode.Selection(new vscode.Position(6, 0), new vscode.Position(7, 0));
+        const highlightedText: vscode.Selection = new vscode.Selection(new vscode.Position(4, 0), new vscode.Position(5, 0));
         vscode.window.showTextDocument(testUri).then((editor: vscode.TextEditor) => {
             events.push(vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => {
                 const result: vscode.TextLine = event.document.lineAt(highlightedText.anchor.line);

--- a/src/test/suite/commands.test.ts
+++ b/src/test/suite/commands.test.ts
@@ -119,6 +119,7 @@ describe('Command: insertLink', function () {
         const highlightedText: vscode.Selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, tid.length));
         vscode.window.showTextDocument(testUri).then((editor: vscode.TextEditor) => {
             events.push(vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => {
+                console.log(JSON.stringify(event.contentChanges));
                 const result: vscode.TextLine = event.document.lineAt(highlightedText.active.line);
                 assert.strictEqual(result.text, expectedMarkdown);
                 done();

--- a/src/test/suite/commands.test.ts
+++ b/src/test/suite/commands.test.ts
@@ -139,8 +139,7 @@ describe('Command: insertLink', function () {
         const result: vscode.TextLine = editor.document.lineAt(highlightedText.anchor.line);
         assert.strictEqual(result.text, expectedMarkdown);
     });
-    it.skip('should identify ATT&CK objects without highlighting text', async function () {
-        // may keep this idea, may not
+    it('should identify ATT&CK objects without highlighting text', async function () {
         const expectedMarkdown: string = `[${attackObjects[0].id}](${attackObjects[0].url})`;
         const tid: string = attackObjects[0].id;
         const cursor: vscode.Position = new vscode.Position(1, tid.length-1);

--- a/src/test/suite/commands.test.ts
+++ b/src/test/suite/commands.test.ts
@@ -119,10 +119,11 @@ describe('Command: insertLink', function () {
         const highlightedText: vscode.Selection = new vscode.Selection(new vscode.Position(1, 0), new vscode.Position(1, tid.length));
         vscode.window.showTextDocument(testUri).then((editor: vscode.TextEditor) => {
             events.push(vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => {
-                console.log(JSON.stringify(event.contentChanges));
-                const result: vscode.TextLine = event.document.lineAt(highlightedText.active.line);
-                assert.strictEqual(result.text, expectedMarkdown);
-                done();
+                if (event.contentChanges.length > 0) {
+                    const result: vscode.TextLine = event.document.lineAt(highlightedText.active.line);
+                    assert.strictEqual(result.text, expectedMarkdown);
+                    done();
+                }
             }));
             editor.selections = [highlightedText];
             vscode.commands.executeCommand('vscode-attack.insertLink', editor, {techniques: attackObjects});
@@ -134,9 +135,11 @@ describe('Command: insertLink', function () {
         const highlightedText: vscode.Selection = new vscode.Selection(new vscode.Position(2, 0), new vscode.Position(2, name.length));
         vscode.window.showTextDocument(testUri).then((editor: vscode.TextEditor) => {
             events.push(vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => {
-                const result: vscode.TextLine = event.document.lineAt(highlightedText.active.line);
-                assert.strictEqual(result.text, expectedMarkdown);
-                done();
+                if (event.contentChanges.length > 0) {
+                    const result: vscode.TextLine = event.document.lineAt(highlightedText.active.line);
+                    assert.strictEqual(result.text, expectedMarkdown);
+                    done();
+                }
             }));
             editor.selections = [highlightedText];
             vscode.commands.executeCommand('vscode-attack.insertLink', editor, {techniques: attackObjects});
@@ -158,9 +161,11 @@ describe('Command: insertLink', function () {
         const highlightedText: vscode.Selection = new vscode.Selection(new vscode.Position(4, 0), new vscode.Position(5, 0));
         vscode.window.showTextDocument(testUri).then((editor: vscode.TextEditor) => {
             events.push(vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => {
-                const result: vscode.TextLine = event.document.lineAt(highlightedText.anchor.line);
-                assert.strictEqual(result.text, expectedMarkdown);
-                done();
+                if (event.contentChanges.length > 0) {
+                    const result: vscode.TextLine = event.document.lineAt(highlightedText.anchor.line);
+                    assert.strictEqual(result.text, expectedMarkdown);
+                    done();
+                }
             }));
             editor.selections = [highlightedText];
             vscode.commands.executeCommand('vscode-attack.insertLink', editor, {techniques: attackObjects});

--- a/src/test/suite/commands.test.ts
+++ b/src/test/suite/commands.test.ts
@@ -1,10 +1,11 @@
 import * as assert from 'assert';
+import * as path from 'path';
 import * as vscode from 'vscode';
 import * as search from '../../search';
 import { disposables, extensionID, ignoreConsoleLogs, resetState } from '../suite/testHelpers';
 
 
-describe('Search Command', function () {
+describe('Command: search', function () {
     const searchCommand = 'vscode-attack.search';
     let ext: vscode.Extension<unknown> | undefined;
 
@@ -68,5 +69,46 @@ describe('Search Command', function () {
             panels.forEach((panel: vscode.WebviewPanel) => { disposables.push(panel); });
             assert.strictEqual(panels.length, 0);
         });
+    });
+});
+
+describe('Command: insertLink', function () {
+    const insertLinkCommand = 'vscode-attack.insertLink';
+    const testPath: string = path.resolve(__dirname, '..', '..', '..', 'src', 'test', 'files', 'test.md');
+    const testUri: vscode.Uri = vscode.Uri.file(testPath);
+    let ext: vscode.Extension<unknown> | undefined;
+
+    before(async function () {
+        ext = vscode.extensions.getExtension(extensionID);
+        await ext?.activate();
+        exports = ext?.exports;
+    });
+    beforeEach(ignoreConsoleLogs);
+    afterEach(resetState);
+    it('insert link command should exist', async function () {
+        const commands: Array<string> = await vscode.commands.getCommands(true);
+        assert.ok(commands.includes(insertLinkCommand), `No '${insertLinkCommand}' exists.`);
+    });
+    it.skip('should insert a link for markdown text', async function () {
+        const tid = 'T1059.001';
+        const expectedLink = 'https://attack.mitre.org/techniques/T1059/001';
+        const editor: vscode.TextEditor = await vscode.window.showTextDocument(testUri);
+        const techniques: Array<Technique> = [
+            {
+                deprecated: false,
+                description: {
+                    short: 'test description',
+                    long: 'longer test description'
+                },
+                id: tid,
+                name: 'test',
+                parent: undefined,
+                revoked: false,
+                subtechnique: true,
+                tactics: [],
+                url: expectedLink,
+            }
+        ];
+        vscode.commands.executeCommand('vscode-attack.insertLink', editor, {techniques: techniques});
     });
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -208,28 +208,24 @@ describe('Extension', function () {
 });
 
 describe('General Settings', function () {
-    // bumping timeout on this due to config updates in afterEach()
-    // ... potentially taking a long time
-    this.timeout(15000);
-
     let ext: vscode.Extension<unknown> | undefined;
     let modifiedConfig: vscode.WorkspaceConfiguration;
-    const defaultFiles: Array<Record<string, unknown>> = [{ "scheme": "file", "language": "markdown" }, { "scheme": "file", "language": "yaml" }];
     const testPath: string = path.resolve(__dirname, '..', '..', '..', 'src', 'test', 'files', 'test.md');
     const testUri: vscode.Uri = vscode.Uri.file(testPath);
 
-    beforeEach(() => {
+    before(async function () {
         ignoreConsoleLogs();
         ext = vscode.extensions.getExtension(extensionID);
+        await ext?.activate();
+        exports = ext?.exports;
         modifiedConfig = vscode.workspace.getConfiguration(configSection);
     });
-    afterEach(async () => {
-        await setTestConfig('debug', false, modifiedConfig);
-        await setTestConfig('description', 'short', modifiedConfig);
-        await setTestConfig('completionFormat', 'id', modifiedConfig);
-        await setTestConfig('applicableFiles', defaultFiles, modifiedConfig);
-        resetState();
+    after(async function () {
+        await setTestConfig('debug', undefined, modifiedConfig);
+        await setTestConfig('description', undefined, modifiedConfig);
     });
+    beforeEach(ignoreConsoleLogs);
+    afterEach(resetState);
     it.skip('debug: should enable debug logging when set', async function () {
         await setTestConfig('debug', true, modifiedConfig);
         ext?.activate().then(() => {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -224,10 +224,10 @@ describe('General Settings', function () {
         modifiedConfig = vscode.workspace.getConfiguration(configSection);
     });
     afterEach(async () => {
-        await modifiedConfig.update('debug', false, vscode.ConfigurationTarget.Global);
-        await modifiedConfig.update('description', 'short', vscode.ConfigurationTarget.Global);
-        await modifiedConfig.update('completionFormat', 'id', vscode.ConfigurationTarget.Global);
-        await modifiedConfig.update('applicableFiles', defaultFiles, vscode.ConfigurationTarget.Global);
+        await setTestConfig('debug', false, modifiedConfig);
+        await setTestConfig('description', 'short', modifiedConfig);
+        await setTestConfig('completionFormat', 'id', modifiedConfig);
+        await setTestConfig('applicableFiles', defaultFiles, modifiedConfig);
         resetState();
     });
     it.skip('debug: should enable debug logging when set', async function () {

--- a/src/test/suite/groups.test.ts
+++ b/src/test/suite/groups.test.ts
@@ -16,10 +16,10 @@ describe('Groups', function () {
         ext = vscode.extensions.getExtension(extensionID);
         await ext?.activate();
         exports = ext?.exports;
-        await modifiedConfig.update('groups', true, vscode.ConfigurationTarget.Global);
+        await setTestConfig('groups', true, modifiedConfig);
     });
     after(async function () {
-        await modifiedConfig.update('groups', false, vscode.ConfigurationTarget.Global);
+        await setTestConfig('groups', undefined, modifiedConfig);
     });
     beforeEach(ignoreConsoleLogs);
     afterEach(resetState);

--- a/src/test/suite/groups.test.ts
+++ b/src/test/suite/groups.test.ts
@@ -9,14 +9,13 @@ describe('Groups', function () {
     const testPath: string = path.resolve(__dirname, '..', '..', '..', 'src', 'test', 'files', 'test.md');
     const testUri: vscode.Uri = vscode.Uri.file(testPath);
     let ext: vscode.Extension<unknown> | undefined;
-    let modifiedConfig: vscode.WorkspaceConfiguration;
+    let modifiedConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(configSection);
 
     before(async function () {
         ignoreConsoleLogs();
         ext = vscode.extensions.getExtension(extensionID);
         await ext?.activate();
         exports = ext?.exports;
-        modifiedConfig = vscode.workspace.getConfiguration(configSection);
         await modifiedConfig.update('groups', true, vscode.ConfigurationTarget.Global);
     });
     after(async function () {
@@ -71,21 +70,90 @@ describe('Group Settings', function () {
     // bumping timeout on this due to config updates in afterEach()
     // ... potentially taking a long time
     this.timeout(5000);
-
-    let modifiedConfig: vscode.WorkspaceConfiguration;
     const testPath: string = path.resolve(__dirname, '..', '..', '..', 'src', 'test', 'files', 'test.md');
     const testUri: vscode.Uri = vscode.Uri.file(testPath);
+    const modifiedConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(configSection);
 
-    beforeEach(() => {
-        ignoreConsoleLogs();
-        modifiedConfig = vscode.workspace.getConfiguration(configSection);
+    before(async function () {
+        await setTestConfig('groups', true, modifiedConfig);
     });
-    afterEach(async () => {
-        await modifiedConfig.update('groups', false, vscode.ConfigurationTarget.Global);
+    beforeEach(async function () {
+        ignoreConsoleLogs();
+    });
+    afterEach(async function () {
         resetState();
     });
+    after(async function () {
+        await setTestConfig('groups', undefined, modifiedConfig);
+        await setTestConfig('completionFormat', undefined, modifiedConfig);
+    });
+    it('completionFormat: should show only an ID when set to id', async function () {
+        const gid = 'G0007';
+        const expectedDetail: string = gid;
+        await setTestConfig('completionFormat', 'id', modifiedConfig);
+        const position: vscode.Position = new vscode.Position(9, gid.length);
+        const results = await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', testUri, position);
+        assert.ok(results instanceof vscode.CompletionList);
+        assert.strictEqual(results.items.length, 1);
+        assert.ok(results.items[0] instanceof vscode.CompletionItem);
+        assert.strictEqual(results.items[0].detail, expectedDetail);
+    });
+    it('completionFormat: should show only a name when set to name', async function () {
+        const gid = 'G0007';
+        const expectedDetail = 'APT28';
+        await setTestConfig('completionFormat', 'name', modifiedConfig);
+        const position: vscode.Position = new vscode.Position(9, gid.length);
+        const results = await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', testUri, position);
+        assert.ok(results instanceof vscode.CompletionList);
+        assert.strictEqual(results.items.length, 1);
+        assert.ok(results.items[0] instanceof vscode.CompletionItem);
+        assert.strictEqual(results.items[0].detail, expectedDetail);
+    });
+    it('completionFormat: should show only a link when set to link', async function () {
+        const gid = 'G0007';
+        const expectedDetail = 'https://attack.mitre.org/groups/G0007';
+        await setTestConfig('completionFormat', 'link', modifiedConfig);
+        const position: vscode.Position = new vscode.Position(9, gid.length);
+        const results = await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', testUri, position);
+        assert.ok(results instanceof vscode.CompletionList);
+        assert.strictEqual(results.items.length, 1);
+        assert.ok(results.items[0] instanceof vscode.CompletionItem);
+        assert.strictEqual(results.items[0].detail, expectedDetail);
+    });
+    it('completionFormat: should show only a name when set to fullname', async function () {
+        const gid = 'G0007';
+        const expectedDetail = 'APT28';
+        await setTestConfig('completionFormat', 'fullname', modifiedConfig);
+        const position: vscode.Position = new vscode.Position(9, gid.length);
+        const results = await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', testUri, position);
+        assert.ok(results instanceof vscode.CompletionList);
+        assert.strictEqual(results.items.length, 1);
+        assert.ok(results.items[0] instanceof vscode.CompletionItem);
+        assert.strictEqual(results.items[0].detail, expectedDetail);
+    });
+    it('completionFormat: should show an ID and name when set to id-name', async function () {
+        const gid = 'G0007';
+        const expectedDetail = `${gid} APT28`;
+        await setTestConfig('completionFormat', 'id-name', modifiedConfig);
+        const position: vscode.Position = new vscode.Position(9, gid.length);
+        const results = await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', testUri, position);
+        assert.ok(results instanceof vscode.CompletionList);
+        assert.strictEqual(results.items.length, 1);
+        assert.ok(results.items[0] instanceof vscode.CompletionItem);
+        assert.strictEqual(results.items[0].detail, expectedDetail);
+    });
+    it('completionFormat: should show an ID and name when set to id-fullname', async function () {
+        const gid = 'G0007';
+        const expectedDetail = `${gid} APT28`;
+        await setTestConfig('completionFormat', 'id-fullname', modifiedConfig);
+        const position: vscode.Position = new vscode.Position(9, gid.length);
+        const results = await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', testUri, position);
+        assert.ok(results instanceof vscode.CompletionList);
+        assert.strictEqual(results.items.length, 1);
+        assert.ok(results.items[0] instanceof vscode.CompletionItem);
+        assert.strictEqual(results.items[0].detail, expectedDetail);
+    });
     it('should enable the Group providers when set to true', async function () {
-        await setTestConfig('groups', true, modifiedConfig);
         const expectedGID = 'G0007';
         const position: vscode.Position = new vscode.Position(9, expectedGID.length);
         const results = await vscode.commands.executeCommand('vscode.executeHoverProvider', testUri, position);

--- a/src/test/suite/mitigations.test.ts
+++ b/src/test/suite/mitigations.test.ts
@@ -16,10 +16,10 @@ describe('Mitigations', function () {
         ext = vscode.extensions.getExtension(extensionID);
         await ext?.activate();
         modifiedConfig = vscode.workspace.getConfiguration(configSection);
-        await modifiedConfig.update('mitigations', true, vscode.ConfigurationTarget.Global);
+        await setTestConfig('mitigations', true, modifiedConfig);
     });
     after(async function () {
-        await modifiedConfig.update('mitigations', false, vscode.ConfigurationTarget.Global);
+        await setTestConfig('mitigations', undefined, modifiedConfig);
     });
     beforeEach(ignoreConsoleLogs);
     afterEach(resetState);

--- a/src/test/suite/mitigations.test.ts
+++ b/src/test/suite/mitigations.test.ts
@@ -70,21 +70,90 @@ describe('Mitigation Settings', function () {
     // bumping timeout on this due to config updates in afterEach()
     // ... potentially taking a long time
     this.timeout(5000);
-
-    let modifiedConfig: vscode.WorkspaceConfiguration;
     const testPath: string = path.resolve(__dirname, '..', '..', '..', 'src', 'test', 'files', 'test.md');
     const testUri: vscode.Uri = vscode.Uri.file(testPath);
+    const modifiedConfig: vscode.WorkspaceConfiguration  = vscode.workspace.getConfiguration(configSection);
 
-    beforeEach(() => {
-        ignoreConsoleLogs();
-        modifiedConfig = vscode.workspace.getConfiguration(configSection);
+    before(async function () {
+        await setTestConfig('mitigations', true, modifiedConfig);
     });
-    afterEach(async () => {
-        await modifiedConfig.update('mitigations', false, vscode.ConfigurationTarget.Global);
+    beforeEach(function () {
+        ignoreConsoleLogs();
+    });
+    afterEach(function () {
         resetState();
     });
+    after(async function () {
+        await setTestConfig('mitigations', undefined, modifiedConfig);
+        await setTestConfig('completionFormat', undefined, modifiedConfig);
+    });
+    it('completionFormat: should show only an ID when set to id', async function () {
+        const mid = 'M1047';
+        const expectedDetail: string = mid;
+        await setTestConfig('completionFormat', 'id', modifiedConfig);
+        const position: vscode.Position = new vscode.Position(13, mid.length);
+        const results = await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', testUri, position);
+        assert.ok(results instanceof vscode.CompletionList);
+        assert.strictEqual(results.items.length, 1);
+        assert.ok(results.items[0] instanceof vscode.CompletionItem);
+        assert.strictEqual(results.items[0].detail, expectedDetail);
+    });
+    it('completionFormat: should show only a name when set to name', async function () {
+        const mid = 'M1047';
+        const expectedDetail = 'Audit';
+        await setTestConfig('completionFormat', 'name', modifiedConfig);
+        const position: vscode.Position = new vscode.Position(13, mid.length);
+        const results = await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', testUri, position);
+        assert.ok(results instanceof vscode.CompletionList);
+        assert.strictEqual(results.items.length, 1);
+        assert.ok(results.items[0] instanceof vscode.CompletionItem);
+        assert.strictEqual(results.items[0].detail, expectedDetail);
+    });
+    it('completionFormat: should show only a link when set to link', async function () {
+        const mid = 'M1047';
+        const expectedDetail = 'https://attack.mitre.org/mitigations/M1047';
+        await setTestConfig('completionFormat', 'link', modifiedConfig);
+        const position: vscode.Position = new vscode.Position(13, mid.length);
+        const results = await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', testUri, position);
+        assert.ok(results instanceof vscode.CompletionList);
+        assert.strictEqual(results.items.length, 1);
+        assert.ok(results.items[0] instanceof vscode.CompletionItem);
+        assert.strictEqual(results.items[0].detail, expectedDetail);
+    });
+    it('completionFormat: should show only a name when set to fullname', async function () {
+        const mid = 'M1047';
+        const expectedDetail = 'Audit';
+        await setTestConfig('completionFormat', 'fullname', modifiedConfig);
+        const position: vscode.Position = new vscode.Position(13, mid.length);
+        const results = await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', testUri, position);
+        assert.ok(results instanceof vscode.CompletionList);
+        assert.strictEqual(results.items.length, 1);
+        assert.ok(results.items[0] instanceof vscode.CompletionItem);
+        assert.strictEqual(results.items[0].detail, expectedDetail);
+    });
+    it('completionFormat: should show an ID and name when set to id-name', async function () {
+        const mid = 'M1047';
+        const expectedDetail = `${mid} Audit`;
+        await setTestConfig('completionFormat', 'id-name', modifiedConfig);
+        const position: vscode.Position = new vscode.Position(13, mid.length);
+        const results = await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', testUri, position);
+        assert.ok(results instanceof vscode.CompletionList);
+        assert.strictEqual(results.items.length, 1);
+        assert.ok(results.items[0] instanceof vscode.CompletionItem);
+        assert.strictEqual(results.items[0].detail, expectedDetail);
+    });
+    it('completionFormat: should show an ID and name when set to id-fullname', async function () {
+        const mid = 'M1047';
+        const expectedDetail = `${mid} Audit`;
+        await setTestConfig('completionFormat', 'id-fullname', modifiedConfig);
+        const position: vscode.Position = new vscode.Position(13, mid.length);
+        const results = await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', testUri, position);
+        assert.ok(results instanceof vscode.CompletionList);
+        assert.strictEqual(results.items.length, 1);
+        assert.ok(results.items[0] instanceof vscode.CompletionItem);
+        assert.strictEqual(results.items[0].detail, expectedDetail);
+    });
     it('should enable the Mitigation providers when set to true', async function () {
-        await setTestConfig('mitigations', true, modifiedConfig);
         const expectedMID = 'M1047';
         const position: vscode.Position = new vscode.Position(13, expectedMID.length);
         const results = await vscode.commands.executeCommand('vscode.executeHoverProvider', testUri, position);

--- a/src/test/suite/software.test.ts
+++ b/src/test/suite/software.test.ts
@@ -17,10 +17,10 @@ describe('Software', function () {
         await ext?.activate();
         exports = ext?.exports;
         modifiedConfig = vscode.workspace.getConfiguration(configSection);
-        await modifiedConfig.update('software', true, vscode.ConfigurationTarget.Global);
+        await setTestConfig('software', true, modifiedConfig);
     });
     after(async function () {
-        await modifiedConfig.update('software', false, vscode.ConfigurationTarget.Global);
+        await setTestConfig('software', undefined, modifiedConfig);
     });
     beforeEach(ignoreConsoleLogs);
     afterEach(resetState);

--- a/src/test/suite/software.test.ts
+++ b/src/test/suite/software.test.ts
@@ -96,7 +96,6 @@ describe('Software Settings', function () {
         const position: vscode.Position = new vscode.Position(11, sid.length);
         const results = await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', testUri, position);
         assert.ok(results instanceof vscode.CompletionList);
-        console.log(JSON.stringify(results));
         assert.strictEqual(results.items.length, 1);
         assert.ok(results.items[0] instanceof vscode.CompletionItem);
         assert.strictEqual(results.items[0].detail, expectedDetail);

--- a/src/test/suite/software.test.ts
+++ b/src/test/suite/software.test.ts
@@ -71,17 +71,95 @@ describe('Software Settings', function () {
     // bumping timeout on this due to config updates in afterEach()
     // ... potentially taking a long time
     this.timeout(5000);
-    let modifiedConfig: vscode.WorkspaceConfiguration;
     const testPath: string = path.resolve(__dirname, '..', '..', '..', 'src', 'test', 'files', 'test.md');
     const testUri: vscode.Uri = vscode.Uri.file(testPath);
+    const modifiedConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(configSection);;
 
-    beforeEach(() => {
-        ignoreConsoleLogs();
-        modifiedConfig = vscode.workspace.getConfiguration(configSection);
+    before(async function () {
+        await setTestConfig('software', true, modifiedConfig);
     });
-    afterEach(async () => {
-        await modifiedConfig.update('software', false, vscode.ConfigurationTarget.Global);
+    beforeEach(function () {
+        ignoreConsoleLogs();
+    });
+    afterEach(async function () {
         resetState();
+    });
+    after(async function () {
+        await setTestConfig('software', undefined, modifiedConfig);
+        await setTestConfig('completionFormat', undefined, modifiedConfig);
+    });
+    it('completionFormat: should show only an ID when set to id', async function () {
+        const sid = 'S0045';
+        const expectedDetail: string = sid;
+        await setTestConfig('software', true, modifiedConfig);
+        await setTestConfig('completionFormat', 'id', modifiedConfig);
+        const position: vscode.Position = new vscode.Position(11, sid.length);
+        const results = await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', testUri, position);
+        assert.ok(results instanceof vscode.CompletionList);
+        console.log(JSON.stringify(results));
+        assert.strictEqual(results.items.length, 1);
+        assert.ok(results.items[0] instanceof vscode.CompletionItem);
+        assert.strictEqual(results.items[0].detail, expectedDetail);
+    });
+    it('completionFormat: should show only a name when set to name', async function () {
+        const sid = 'S0045';
+        const expectedDetail = 'ADVSTORESHELL';
+        await setTestConfig('software', true, modifiedConfig);
+        await setTestConfig('completionFormat', 'name', modifiedConfig);
+        const position: vscode.Position = new vscode.Position(11, sid.length);
+        const results = await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', testUri, position);
+        assert.ok(results instanceof vscode.CompletionList);
+        assert.strictEqual(results.items.length, 1);
+        assert.ok(results.items[0] instanceof vscode.CompletionItem);
+        assert.strictEqual(results.items[0].detail, expectedDetail);
+    });
+    it('completionFormat: should show only a link when set to link', async function () {
+        const sid = 'S0045';
+        const expectedDetail = 'https://attack.mitre.org/software/S0045';
+        await setTestConfig('software', true, modifiedConfig);
+        await setTestConfig('completionFormat', 'link', modifiedConfig);
+        const position: vscode.Position = new vscode.Position(11, sid.length);
+        const results = await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', testUri, position);
+        assert.ok(results instanceof vscode.CompletionList);
+        assert.strictEqual(results.items.length, 1);
+        assert.ok(results.items[0] instanceof vscode.CompletionItem);
+        assert.strictEqual(results.items[0].detail, expectedDetail);
+    });
+    it('completionFormat: should show only a name when set to fullname', async function () {
+        const sid = 'S0045';
+        const expectedDetail = 'ADVSTORESHELL';
+        await setTestConfig('software', true, modifiedConfig);
+        await setTestConfig('completionFormat', 'fullname', modifiedConfig);
+        const position: vscode.Position = new vscode.Position(11, sid.length);
+        const results = await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', testUri, position);
+        assert.ok(results instanceof vscode.CompletionList);
+        assert.strictEqual(results.items.length, 1);
+        assert.ok(results.items[0] instanceof vscode.CompletionItem);
+        assert.strictEqual(results.items[0].detail, expectedDetail);
+    });
+    it('completionFormat: should show an ID and name when set to id-name', async function () {
+        const sid = 'S0045';
+        const expectedDetail = `${sid} ADVSTORESHELL`;
+        await setTestConfig('software', true, modifiedConfig);
+        await setTestConfig('completionFormat', 'id-name', modifiedConfig);
+        const position: vscode.Position = new vscode.Position(11, sid.length);
+        const results = await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', testUri, position);
+        assert.ok(results instanceof vscode.CompletionList);
+        assert.strictEqual(results.items.length, 1);
+        assert.ok(results.items[0] instanceof vscode.CompletionItem);
+        assert.strictEqual(results.items[0].detail, expectedDetail);
+    });
+    it('completionFormat: should show an ID and name when set to id-fullname', async function () {
+        const sid = 'S0045';
+        const expectedDetail = `${sid} ADVSTORESHELL`;
+        await setTestConfig('software', true, modifiedConfig);
+        await setTestConfig('completionFormat', 'id-fullname', modifiedConfig);
+        const position: vscode.Position = new vscode.Position(11, sid.length);
+        const results = await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', testUri, position);
+        assert.ok(results instanceof vscode.CompletionList);
+        assert.strictEqual(results.items.length, 1);
+        assert.ok(results.items[0] instanceof vscode.CompletionItem);
+        assert.strictEqual(results.items[0].detail, expectedDetail);
     });
     it('should enable the Software providers when set to true', async function () {
         await setTestConfig('software', true, modifiedConfig);

--- a/src/test/suite/techniques.test.ts
+++ b/src/test/suite/techniques.test.ts
@@ -1,7 +1,6 @@
 import * as assert from 'assert';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as search from '../../search';
 import { techniqueRegex } from '../../helpers';
 import { ATTACKExtensionAPI, configSection, disposables, extensionID, ignoreConsoleLogs, resetState, setTestConfig } from '../suite/testHelpers';
 
@@ -186,73 +185,6 @@ describe('Techniques', function () {
         // completion provider only applies to non-revoked techniques
         const techniques: Array<Technique> = exports.getCurrentTechniques();
         assert.strictEqual(results.items.length, techniques.length);
-    });
-});
-
-describe('Technique Search', function () {
-    const searchCommand = 'vscode-attack.search';
-    let ext: vscode.Extension<unknown> | undefined;
-
-    before(async function () {
-        ext = vscode.extensions.getExtension(extensionID);
-        await ext?.activate();
-        exports = ext?.exports;
-    });
-    beforeEach(ignoreConsoleLogs);
-    afterEach(resetState);
-    it('search command should exist', function () {
-        vscode.commands.getCommands(true).then((commands: string[]) => {
-            assert.ok(commands.includes(searchCommand), `No '${searchCommand}' exists.`);
-        });
-    });
-    it('should open one webpanel for exact TIDs', function () {
-        const tid = 'T1059.001';
-        const expectedTitle = `${tid}: PowerShell`;
-        search.search(exports.getAllTechniques(), tid).then((panels: Array<vscode.WebviewPanel>) => {
-            panels.forEach((panel: vscode.WebviewPanel) => { disposables.push(panel); });
-            assert.strictEqual(panels.length, 1);
-            assert.strictEqual(panels[0].title, expectedTitle);
-        });
-    });
-    it('should open one webpanel for revoked TIDs', async function () {
-        const tid = 'T1086';
-        const expectedTitle = `${tid}: PowerShell`;
-        const expectedText = `<h3>PowerShell (REVOKED)</h3>`;
-        search.search(exports.getAllTechniques(), tid).then((panels: Array<vscode.WebviewPanel>) => {
-            panels.forEach((panel: vscode.WebviewPanel) => { disposables.push(panel); });
-            assert.strictEqual(panels.length, 1);
-            assert.strictEqual(panels[0].title, expectedTitle);
-            assert.ok(panels[0].webview.html.includes(expectedText));
-        });
-    });
-    it('should open all webpanels containing a technique name', async function () {
-        const name = 'PowerShell';
-        // Should return both 'PowerShell' and 'PowerShell Profile'
-        const expectedTitles: Array<string> = ['T1059.001: PowerShell', 'T1546.013: PowerShell Profile'];
-        search.search(exports.getAllTechniques(), name).then((panels: Array<vscode.WebviewPanel>) => {
-            panels.forEach((panel: vscode.WebviewPanel) => { disposables.push(panel); });
-            assert.strictEqual(panels.length, 2);
-            const titles: Array<string> = panels.map<string>((panel: vscode.WebviewPanel) => { return panel.title; });
-            assert.deepStrictEqual(titles, expectedTitles);
-        });
-    });
-    it('should open all webpanels for lengthy terms in technique descriptions', async function () {
-        // this term is not a technique ID or in any technique name
-        // so the only way it would return an item is if the descriptions are searched
-        const term = 'certutil';
-        const expectedTitle = 'T1140: Deobfuscate/Decode Files or Information';
-        search.search(exports.getAllTechniques(), term).then((panels: Array<vscode.WebviewPanel>) => {
-            panels.forEach((panel: vscode.WebviewPanel) => { disposables.push(panel); });
-            assert.strictEqual(panels.length, 1);
-            assert.strictEqual(panels[0].title, expectedTitle);
-        });
-    });
-    it('should not search for short terms in technique descriptions', async function () {
-        const term = 'the';
-        search.search(exports.getAllTechniques(), term).then((panels: Array<vscode.WebviewPanel>) => {
-            panels.forEach((panel: vscode.WebviewPanel) => { disposables.push(panel); });
-            assert.strictEqual(panels.length, 0);
-        });
     });
 });
 

--- a/src/test/suite/techniques.test.ts
+++ b/src/test/suite/techniques.test.ts
@@ -260,22 +260,21 @@ describe('Technique Settings', function () {
     // bumping timeout on this due to config updates in afterEach()
     // ... potentially taking a long time
     this.timeout(5000);
-
-    const modifiedConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(configSection);
     const testPath: string = path.resolve(__dirname, '..', '..', '..', 'src', 'test', 'files', 'test.md');
     const testUri: vscode.Uri = vscode.Uri.file(testPath);
+    const modifiedConfig: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(configSection);
 
     before(async () => {
-        await setTestConfig('completionFormat', 'id', modifiedConfig);
-        await setTestConfig('description', 'short', modifiedConfig);
         await setTestConfig('techniques', true, modifiedConfig);
     });
     beforeEach(ignoreConsoleLogs);
     afterEach(async () => {
-        await setTestConfig('completionFormat', 'id', modifiedConfig);
-        await setTestConfig('description', 'short', modifiedConfig);
-        await setTestConfig('techniques', true, modifiedConfig);
         resetState();
+    });
+    after(async () => {
+        await setTestConfig('techniques', undefined, modifiedConfig);
+        await setTestConfig('completionFormat', undefined, modifiedConfig);
+        await setTestConfig('description', undefined, modifiedConfig);
     });
     it('completionFormat: should show only a TID when set to id', async function () {
         const tid = 'T1059.001';
@@ -292,6 +291,17 @@ describe('Technique Settings', function () {
         const tid = 'T1059.001';
         const expectedDetail = 'PowerShell';
         await setTestConfig('completionFormat', 'name', modifiedConfig);
+        const position: vscode.Position = new vscode.Position(1, tid.length);
+        const results = await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', testUri, position);
+        assert.ok(results instanceof vscode.CompletionList);
+        assert.strictEqual(results.items.length, 1);
+        assert.ok(results.items[0] instanceof vscode.CompletionItem);
+        assert.strictEqual(results.items[0].detail, expectedDetail);
+    });
+    it('completionFormat: should show only a link when set to link', async function () {
+        const tid = 'T1059.001';
+        const expectedDetail = 'https://attack.mitre.org/techniques/T1059/001';
+        await setTestConfig('completionFormat', 'link', modifiedConfig);
         const position: vscode.Position = new vscode.Position(1, tid.length);
         const results = await vscode.commands.executeCommand('vscode.executeCompletionItemProvider', testUri, position);
         assert.ok(results instanceof vscode.CompletionList);


### PR DESCRIPTION
Closes issue #2 

This PR concerns two main changes:
1. A new completion format - `link` - which will insert a raw link to the `attack.mitre.org` website when attempting to complete any ATT&CK object by ID or name
2. A new command: `vscode-attack.insertLink`. This command allows users to convert preexisting ATT&CK object IDs and names into Markdown-formatted links either by placing a cursor in the text or highlighting one or multiple words to wrap the link around. At the moment, `markdown` files are the only ones supported, but more can be added easily in the future.
  * One important caveat of multi-word support is that it only exists when highlighting text. For example, attempting to link `Defense Evasion` to `TA0005` requires the user to select + highlight both words completely, without extra space. Merely placing a cursor in either word or the space in between is not enough. 
  * Another caveat is revoked techniques are not supported by the `insertLink` command at all
