### PR TITLE
Fix to make the InsertLink command case-insensitive

### DIFF
--- a/src/insertLink.ts
+++ b/src/insertLink.ts
@@ -15,6 +15,18 @@ function generateLink(text: string, url: string): string|undefined {
     return link;
 }
 
+/*
+    Compare a given string to an object's ID or name case insensitively
+*/
+function isMatching(text: string, attackObject: Group|Mitigation|Software|Tactic|Technique): boolean {
+    const textLower: string = text.toLocaleLowerCase();
+    const result: boolean = attackObject.id.toLocaleLowerCase() === textLower || attackObject.name.toLocaleLowerCase() === textLower;
+    // if (result === true) {
+    //     console.log(`${text} === ${attackObject.id} || ${attackObject.name}`);
+    // }
+    return result;
+}
+
 export function insertLink(editor: vscode.TextEditor|undefined, groups: Array<Group>=[],
                            mitigations: Array<Mitigation>=[], software: Array<Software>=[],
                            tactics: Array<Tactic>=[], techniques: Array<Technique>=[]): void {
@@ -48,24 +60,26 @@ export function insertLink(editor: vscode.TextEditor|undefined, groups: Array<Gr
         // text was found, now to figure out which ATT&CK object it identifies
         const trimmedText = highlightedText.trimRight();
         if (debug) { log(`insertLink: Text to insert a link for: '${trimmedText}'`); }
+        console.log(`insertLink: Text to insert a link for: '${trimmedText}'`);
         const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(configSection);
         let matchingObject: Group|Mitigation|Software|Tactic|Technique|undefined = undefined;
         // search all ATT&CK types for the first matching ID
         if (matchingObject === undefined && configuration.get('groups')) {
-            matchingObject = groups.find((g: Group) => { return g.id === trimmedText || g.name === trimmedText; });
+            matchingObject = groups.find((g: Group) => { return isMatching(trimmedText, g); });
         }
         if (matchingObject === undefined && configuration.get('mitigations')) {
-            matchingObject = mitigations.find((m: Mitigation) => { return m.id === trimmedText || m.name === trimmedText; });
+            matchingObject = mitigations.find((m: Mitigation) => { return isMatching(trimmedText, m); });
         }
         if (matchingObject === undefined && configuration.get('software')) {
-            matchingObject = software.find((s: Software) => { return s.id === trimmedText || s.name === trimmedText; });
+            matchingObject = software.find((s: Software) => { return isMatching(trimmedText, s); });
         }
         if (matchingObject === undefined && configuration.get('tactics')) {
-            matchingObject = tactics.find((t: Tactic) => { return t.id === trimmedText || t.name === trimmedText; });
+            matchingObject = tactics.find((t: Tactic) => { return isMatching(trimmedText, t); });
         }
         if (matchingObject === undefined && configuration.get('techniques')) {
-            matchingObject = techniques.find((t: Technique) => { return t.id === trimmedText || t.name === trimmedText; });
+            matchingObject = techniques.find((t: Technique) => { return isMatching(trimmedText, t); });
         }
+
         if (matchingObject === undefined) {
             // doesn't look like the highlighted text resembles any ATT&CK object we're aware of
             if (debug) { log(`insertLink: Did not find a matching object for '${trimmedText}'`); }

--- a/src/insertLink.ts
+++ b/src/insertLink.ts
@@ -20,11 +20,7 @@ function generateLink(text: string, url: string): string|undefined {
 */
 function isMatching(text: string, attackObject: Group|Mitigation|Software|Tactic|Technique): boolean {
     const textLower: string = text.toLocaleLowerCase();
-    const result: boolean = attackObject.id.toLocaleLowerCase() === textLower || attackObject.name.toLocaleLowerCase() === textLower;
-    // if (result === true) {
-    //     console.log(`${text} === ${attackObject.id} || ${attackObject.name}`);
-    // }
-    return result;
+    return attackObject.id.toLocaleLowerCase() === textLower || attackObject.name.toLocaleLowerCase() === textLower;
 }
 
 export function insertLink(editor: vscode.TextEditor|undefined, groups: Array<Group>=[],
@@ -60,7 +56,6 @@ export function insertLink(editor: vscode.TextEditor|undefined, groups: Array<Gr
         // text was found, now to figure out which ATT&CK object it identifies
         const trimmedText = highlightedText.trimRight();
         if (debug) { log(`insertLink: Text to insert a link for: '${trimmedText}'`); }
-        console.log(`insertLink: Text to insert a link for: '${trimmedText}'`);
         const configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(configSection);
         let matchingObject: Group|Mitigation|Software|Tactic|Technique|undefined = undefined;
         // search all ATT&CK types for the first matching ID

--- a/src/test/files/links.md
+++ b/src/test/files/links.md
@@ -3,3 +3,5 @@ T1059.001
 PowerShell
 certutil
 TA0002
+t1059.001
+powershell

--- a/src/test/suite/commands.test.ts
+++ b/src/test/suite/commands.test.ts
@@ -129,10 +129,42 @@ describe('Command: insertLink', function () {
             vscode.commands.executeCommand('vscode-attack.insertLink', editor, {techniques: attackObjects});
         });
     });
+    it('should insert a link for ATT&CK object IDs case insensitively', function (done) {
+        const expectedMarkdown: string = `[${attackObjects[0].id}](${attackObjects[0].url})`;
+        const tid: string = attackObjects[0].id;
+        const highlightedText: vscode.Selection = new vscode.Selection(new vscode.Position(5, 0), new vscode.Position(5, tid.length));
+        vscode.window.showTextDocument(testUri).then((editor: vscode.TextEditor) => {
+            events.push(vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => {
+                if (event.contentChanges.length > 0) {
+                    const result: vscode.TextLine = event.document.lineAt(highlightedText.active.line);
+                    assert.strictEqual(result.text, expectedMarkdown);
+                    done();
+                }
+            }));
+            editor.selections = [highlightedText];
+            vscode.commands.executeCommand('vscode-attack.insertLink', editor, {techniques: attackObjects});
+        });
+    });
     it('should insert a link for ATT&CK object names', function (done) {
         const expectedMarkdown: string = `[${attackObjects[0].name}](${attackObjects[0].url})`;
         const name: string = attackObjects[0].name;
         const highlightedText: vscode.Selection = new vscode.Selection(new vscode.Position(2, 0), new vscode.Position(2, name.length));
+        vscode.window.showTextDocument(testUri).then((editor: vscode.TextEditor) => {
+            events.push(vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => {
+                if (event.contentChanges.length > 0) {
+                    const result: vscode.TextLine = event.document.lineAt(highlightedText.active.line);
+                    assert.strictEqual(result.text, expectedMarkdown);
+                    done();
+                }
+            }));
+            editor.selections = [highlightedText];
+            vscode.commands.executeCommand('vscode-attack.insertLink', editor, {techniques: attackObjects});
+        });
+    });
+    it('should insert a link for ATT&CK object names case insensitively', function (done) {
+        const expectedMarkdown: string = `[${attackObjects[0].name}](${attackObjects[0].url})`;
+        const name: string = attackObjects[0].name;
+        const highlightedText: vscode.Selection = new vscode.Selection(new vscode.Position(6, 0), new vscode.Position(6, name.length));
         vscode.window.showTextDocument(testUri).then((editor: vscode.TextEditor) => {
             events.push(vscode.workspace.onDidChangeTextDocument((event: vscode.TextDocumentChangeEvent) => {
                 if (event.contentChanges.length > 0) {

--- a/src/test/suite/commands.test.ts
+++ b/src/test/suite/commands.test.ts
@@ -130,7 +130,7 @@ describe('Command: insertLink', function () {
         });
     });
     it('should insert a link for ATT&CK object IDs case insensitively', function (done) {
-        const expectedMarkdown: string = `[${attackObjects[0].id}](${attackObjects[0].url})`;
+        const expectedMarkdown: string = `[${attackObjects[0].id.toLocaleLowerCase()}](${attackObjects[0].url})`;
         const tid: string = attackObjects[0].id;
         const highlightedText: vscode.Selection = new vscode.Selection(new vscode.Position(5, 0), new vscode.Position(5, tid.length));
         vscode.window.showTextDocument(testUri).then((editor: vscode.TextEditor) => {
@@ -162,7 +162,7 @@ describe('Command: insertLink', function () {
         });
     });
     it('should insert a link for ATT&CK object names case insensitively', function (done) {
-        const expectedMarkdown: string = `[${attackObjects[0].name}](${attackObjects[0].url})`;
+        const expectedMarkdown: string = `[${attackObjects[0].name.toLocaleLowerCase()}](${attackObjects[0].url})`;
         const name: string = attackObjects[0].name;
         const highlightedText: vscode.Selection = new vscode.Selection(new vscode.Position(6, 0), new vscode.Position(6, name.length));
         vscode.window.showTextDocument(testUri).then((editor: vscode.TextEditor) => {


### PR DESCRIPTION
Command should match instances of terms with different cases (e.g. `powershell` instead of `PowerShell`)