### PR TITLE
Fix broken test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 node_modules/
 out/
 *.vsix
+.vscode-test/

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
         "lint": "eslint --ext .ts src/",
         "linttests": "eslint --ext .ts test/",
         "package-web": "webpack --mode production --devtool hidden-source-map",
-        "pretest": "npm run compile",
+        "pretest": "npm run compile && npm run test-compile",
         "run-in-browser": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=. .",
         "test": "node ./out/test/runTest.js",
         "test-compile": "tsc -p ./",


### PR DESCRIPTION
Add `test-compile` script to `pretest` to ensure `runTests.js` is present